### PR TITLE
Fix relative resources in redirected page

### DIFF
--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -3,7 +3,7 @@
 const url = require('url');
 const path = require('path');
 const Promise = require('bluebird');
-const normalizeUrl = require('normalize-url');
+const normalize = require('normalize-url');
 const htmlEntities = require('he');
 const _ = require('lodash');
 const typeByMime = require('../config/resource-type-by-mime');
@@ -66,7 +66,7 @@ function getFilenameFromUrl (u) {
  * @returns {string} path
  */
 function getFilepathFromUrl (u) {
-	var nu = normalizeUrl(u);
+	const nu = normalizeUrl(u, {removeTrailingSlash: true});
 	return getPathnameFromUrl(nu).substring(1);
 }
 
@@ -107,6 +107,10 @@ function waitAllFulfilled (promises) {
 	return Promise.all(promises.map(function returnWhenFulfilled (promise) {
 		return promise.reflect();
 	}));
+}
+
+function normalizeUrl (u, opts) {
+	return normalize(u, extend({removeTrailingSlash: false}, opts));
 }
 
 function urlsEqual (url1, url2) {

--- a/test/functional/redirect/mocks/relative-resources-about.html
+++ b/test/functional/redirect/mocks/relative-resources-about.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>About</title>
+    <link rel="stylesheet" type="text/css" href="/style.css"/> <!-- /style.css -->
+    <link rel="stylesheet" type="text/css" href="style.css"/> <!-- /about/style.css -->
+</head>
+<body>
+
+</body>
+</html>

--- a/test/functional/redirect/mocks/relative-resources-index.html
+++ b/test/functional/redirect/mocks/relative-resources-index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Index</title>
+    <link rel="stylesheet" type="text/css" href="style.css"/>
+</head>
+<body>
+    <a href="/about">About</a>
+</body>
+</html>

--- a/test/unit/utils/utils-test.js
+++ b/test/unit/utils/utils-test.js
@@ -220,4 +220,10 @@ describe('Utils', function () {
 			should(utils.decodeHtmlEntities('?a=1&amp;v=2')).be.eql('?a=1&v=2');
 		});
 	});
+
+	describe('#urlsEqual', () => {
+		it('should return false for /path and /path/', function() {
+			should(utils.urlsEqual('http://example.com/path', 'http://example.com/path/')).be.eql(false);
+		});
+	})
 });


### PR DESCRIPTION
If we link to `http://example.com/about` which redirects to `http://example.com/about/` then relative resource url is incorrect because it is calculated using 1st url (`/about`), but should use updated url (`/about/`)