### PR TITLE
chore(package): update request to version 2.85.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.11.1",
     "normalize-url": "^2.0.0",
     "p-queue": "^2.1.0",
-    "request": "^2.81.0",
+    "request": "^2.85.0",
     "srcset": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade to 2.85 because 2.84 is broken
closes #267 