### PR TITLE
Stop downloading children files of img tag or has image extension

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -6,8 +6,8 @@ const config = {
 	sources: [
 		{ selector: 'style' },
 		{ selector: '[style]', attr: 'style' },
-		{ selector: 'img', attr: 'src' },
-		{ selector: 'img', attr: 'srcset' },
+		{ selector: 'img', attr: 'src', no_download_child : true },
+		{ selector: 'img', attr: 'srcset', no_download_child : true },
 		{ selector: 'input', attr: 'src' },
 		{ selector: 'object', attr: 'data' },
 		{ selector: 'embed', attr: 'src' },
@@ -37,7 +37,7 @@ const config = {
 		{ selector: 'iframe', attr: 'src' }
 	],
 	subdirectories: [
-		{ directory: 'images', extensions: ['.png', '.jpg', '.jpeg', '.gif', '.webp'] },
+		{ directory: 'images', extensions: ['.png', '.jpg', '.jpeg', '.gif', '.webp'], no_download_child : true },
 		{ directory: 'js', extensions: ['.js'] },
 		{ directory: 'css', extensions: ['.css'] },
 		{ directory: 'media', extensions: ['.mp4', '.mp3', '.ogg', '.webm', '.mov', '.wave', '.wav', '.flac'] },

--- a/lib/resource-handler/html/index.js
+++ b/lib/resource-handler/html/index.js
@@ -46,6 +46,10 @@ class HtmlResourceHandler {
 				return Promise.resolve(null);
 			}
 
+			if (el.rule.selector) {
+				pathContainer.selector = el.rule.selector;
+			}
+
 			const needToDownloadElement = this.needToDownload(el);
 			const needToUpdateElement = this.needToUpdate(el);
 

--- a/lib/resource-handler/index.js
+++ b/lib/resource-handler/index.js
@@ -54,6 +54,7 @@ class ResourceHandler {
 		const childrenPromises = childrenPaths.map((childPath) => {
 			const childResourceUrl = utils.getUrl(parentResource.getUrl(), childPath);
 			const childResource = parentResource.createChild(childResourceUrl);
+			childResource.selector = pathContainer.selector;
 
 			return self.context.requestResource(childResource).then((respondedResource) => {
 				if (respondedResource) {

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -92,4 +92,25 @@ Resource.prototype.setMetadata = function setMetadata (metadata) {
 	this.metadata = metadata;
 };
 
+Resource.prototype.checkDownloadChild = function checkDownloadChild (defaultConfig) {
+	for(var dindex in defaultConfig.subdirectories){
+		var dobj = defaultConfig.subdirectories[dindex];
+		if (dobj.no_download_child) {
+			for(var eindex in dobj.extensions){
+				if (this.ext == dobj.extensions[eindex]) {
+					return false;
+				}
+			}
+		}
+	}
+
+	for(var sindex in defaultConfig.sources){
+		var source = defaultConfig.sources[sindex];
+		if (source.no_download_child && source.selector == this.selector) {
+			return false;
+		}
+	}
+	return true;
+};
+
 module.exports = Resource;

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -133,6 +133,14 @@ Scraper.prototype.createNewRequest = function createNewRequest (resource) {
 Scraper.prototype.requestResource = function requestResource (resource) {
 	const url = resource.getUrl();
 
+	if (resource.parent) {
+		resource.parent.ext = u.getFilenameExtension(resource.parent.filename);
+		if (!resource.parent.checkDownloadChild(defaults)) {
+			logger.debug('filtering out ' + resource + ' : parent resource has image file extension or is image tag');
+			return Promise.resolve(null);
+		}
+	}
+
 	if (this.options.urlFilter && !this.options.urlFilter(url)) {
 		logger.debug('filtering out ' + resource + ' by url filter');
 		return Promise.resolve(null);


### PR DESCRIPTION
Very nice scraper!!!
But the scraper doesn't stop downloading files with this url.
http://mmbookdownload.com
Seems like the site contains some broken links and if the link is broken, it returns random HTML.

Eternal downloading this website, can be stopped if maxDepth is set, but as I don't want to use max depth.
So, I blocked downloading the child elements of img tag or image file extensions.

P.S. I'm still learning about node.js.
I hope what I'm doing is not wrong.