### PR TITLE
Enable fileNameGenerator byType to read Javscript files by mimeType. Curr…

### DIFF
--- a/lib/config/resource-ext-by-type.js
+++ b/lib/config/resource-ext-by-type.js
@@ -4,5 +4,6 @@ var defaultExtensions = {};
 // should contain same data as ./resource-type-by-ext
 defaultExtensions[types.html] = [ '.html', '.htm' ];
 defaultExtensions[types.css] = [ '.css' ];
+defaultExtensions[types.js] = [ '.js' ];
 
 module.exports = defaultExtensions;

--- a/lib/config/resource-type-by-ext.js
+++ b/lib/config/resource-type-by-ext.js
@@ -5,6 +5,5 @@ module.exports = {
 	'.html': types.html,
 	'.htm': types.html,
 	'.css': types.css,
-	'.js': types.js,
-	'.min.js': types.js
+	'.js': types.js
 };

--- a/lib/config/resource-type-by-ext.js
+++ b/lib/config/resource-type-by-ext.js
@@ -4,5 +4,7 @@ var types = require('./resource-types');
 module.exports = {
 	'.html': types.html,
 	'.htm': types.html,
-	'.css': types.css
+	'.css': types.css,
+	'.js': types.js,
+	'.min.js': types.js
 };

--- a/lib/config/resource-type-by-mime.js
+++ b/lib/config/resource-type-by-mime.js
@@ -2,5 +2,6 @@ var types = require('./resource-types');
 
 module.exports = {
 	'text/html': types.html,
-	'text/css': types.css
+	'text/css': types.css,
+	'text/javascript': types.js
 };

--- a/lib/config/resource-types.js
+++ b/lib/config/resource-types.js
@@ -1,6 +1,7 @@
 var types = {
 	css: 'css',
-	html: 'html'
+	html: 'html',
+	js: 'js'
 };
 
 module.exports = types;

--- a/test/unit/filename-generator/by-type-test.js
+++ b/test/unit/filename-generator/by-type-test.js
@@ -38,6 +38,13 @@ describe('FilenameGenerator: byType', function() {
 		filename.should.equalFileSystemPath('css.css');
 	});
 
+	it('should add missed extensions for js resources', function () {
+		var r = new Resource('http://example.com/js', '');
+		r.getType = sinon.stub().returns('js');
+		var filename = byTypeFilenameGenerator(r, {}, []);
+		filename.should.equalFileSystemPath('js.js');
+	});
+
 	it('should not add missed extensions for other resources', function () {
 		var r = new Resource('http://1.gravatar.com/avatar/4d63e4a045c7ff22accc33dc08442f86?s=140&amp;d=%2Fwp-content%2Fuploads%2F2015%2F05%2FGood-JOb-150x150.jpg&amp;r=g', '');
 		r.getType = sinon.stub().returns('home');


### PR DESCRIPTION
Enable fileNameGenerator "byType" to read Javscript files by mimeType. Currently code only enables CSS and HTML files by mimeType.