### PR TITLE
[new option: overwite] 2use the same output folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ scrape(options, (error, result) => {});
 ## options
 * [urls](#urls) - urls to download, *required*
 * [directory](#directory) - path to save files, *required*
+* [overwrite](#overwrite) - doesn't check output directory
 * [sources](#sources) - selects which resources should be downloaded
 * [recursive](#recursive) - follow hyperlinks in html files
 * [maxRecursiveDepth](#maxrecursivedepth) - maximum depth for hyperlinks
@@ -78,6 +79,9 @@ scrape({
 
 #### directory
 String, absolute path to directory where downloaded files will be saved. Directory should not exist. It will be created by scraper. **_Required_**.
+
+#### overwrite
+Boolean, if `true` scraper doesn't check the output directory and allows to use it for updating files.  Defaults to `false`.
 
 #### sources
 Array of objects to download, specifies selectors and attribute values to select files for downloading. By default scraper tries to download all possible resources.

--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -12,7 +12,7 @@ class SaveResourceToFileSystemPlugin {
 
 			absoluteDirectoryPath = path.resolve(process.cwd(), options.directory);
 
-			if (options.overwrite || fs.existsSync(absoluteDirectoryPath)) {
+			if (!options.overwrite && fs.existsSync(absoluteDirectoryPath)) {
 				throw new Error(`Directory ${absoluteDirectoryPath} exists`);
 			}
 		});

--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -12,7 +12,7 @@ class SaveResourceToFileSystemPlugin {
 
 			absoluteDirectoryPath = path.resolve(process.cwd(), options.directory);
 
-			if (fs.existsSync(absoluteDirectoryPath)) {
+			if (options.overwrite || fs.existsSync(absoluteDirectoryPath)) {
 				throw new Error(`Directory ${absoluteDirectoryPath} exists`);
 			}
 		});


### PR DESCRIPTION
this option prevent error `Error: Directory /var/www/.... exists` and add an ability to sync main folder without the useless folder manipulations