### PR TITLE
Expose response data to generateFilename plugin event

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -174,7 +174,7 @@ class Scraper {
 
 				resource.setType(getTypeByMime(responseData.mimeType));
 
-				const { filename } = await self.runActions('generateFilename', { resource });
+				const { filename } = await self.runActions('generateFilename', { resource, responseData });
 				resource.setFilename(filename);
 
 				// if type was not determined by mime we can try to get it from filename after it was generated


### PR DESCRIPTION
After storing some metadata from the afterResponse handler it should be possible to use that metadata when generating the filename