### PR TITLE
fix(html encoding on 'saveResource')

### DIFF
--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -20,7 +20,7 @@ class SaveResourceToFileSystemPlugin {
 		registerAction('saveResource', async ({resource}) => {
 			const filename = path.join(absoluteDirectoryPath, resource.getFilename());
 			const text = resource.getText();
-			await fs.outputFile(filename, text, { encoding: 'binary' });
+			await fs.outputFile(filename, text, { encoding: resource.type === 'html' ? 'utf8' : 'binary' });
 			loadedResources.push(resource);
 		});
 


### PR DESCRIPTION
Hello, 

As mentioned in the following issue reported on the _website-scraper-puppeteer_ repository by @luckyCoco3418, html files were encoded to binary instead of utf8 when downloaded using fs. 

https://github.com/website-scraper/website-scraper-puppeteer/issues/7

Here is the fix he suggested