### PR TITLE
Add background attribute to default sources

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -32,7 +32,8 @@ const config = {
 		{ selector: 'audio source', attr: 'src' },
 		{ selector: 'audio track', attr: 'src' },
 		{ selector: 'frame', attr: 'src' },
-		{ selector: 'iframe', attr: 'src' }
+		{ selector: 'iframe', attr: 'src' },
+		{ selector: '[background]', attr: 'background' }
 	],
 	subdirectories: [
 		{ directory: 'images', extensions: ['.png', '.jpg', '.jpeg', '.gif', '.webp'] },


### PR DESCRIPTION
Add rule to find resources from tags like `<tagname background = "Image URL"...>`
The background attribute deprecated in HTML5 but still may be used in old websites

Relates to https://github.com/website-scraper/website-scraper-puppeteer/issues/16