### PR TITLE
Feat: allow to save on existing directory

### DIFF
--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -12,9 +12,9 @@ class SaveResourceToFileSystemPlugin {
 
 			absoluteDirectoryPath = path.resolve(process.cwd(), options.directory);
 
-			if (fs.existsSync(absoluteDirectoryPath)) {
-				throw new Error(`Directory ${absoluteDirectoryPath} exists`);
-			}
+			// if (fs.existsSync(absoluteDirectoryPath)) {
+			// 	throw new Error(`Directory ${absoluteDirectoryPath} exists`);
+			// }
 		});
 
 		registerAction('saveResource', async ({resource}) => {

--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -11,10 +11,6 @@ class SaveResourceToFileSystemPlugin {
 			}
 
 			absoluteDirectoryPath = path.resolve(process.cwd(), options.directory);
-
-			// if (fs.existsSync(absoluteDirectoryPath)) {
-			// 	throw new Error(`Directory ${absoluteDirectoryPath} exists`);
-			// }
 		});
 
 		registerAction('saveResource', async ({resource}) => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dwicao-website-scraper",
+  "name": "website-scraper",
   "version": "4.2.1",
   "description": "Download website to a local directory (including all css, images, js, etc.)",
   "readmeFilename": "README.md",
@@ -26,7 +26,7 @@
     "image",
     "js"
   ],
-  "author": "Lutfi Dwica <dwicao.com@gmail.com> (https://dwicao.com/)",
+  "author": "Sophia Antipenko <sophia@antipenko.pp.ua>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/website-scraper/node-website-scraper/issues"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "website-scraper",
+  "name": "dwicao-website-scraper",
   "version": "4.2.1",
   "description": "Download website to a local directory (including all css, images, js, etc.)",
   "readmeFilename": "README.md",
@@ -26,7 +26,7 @@
     "image",
     "js"
   ],
-  "author": "Sophia Antipenko <sophia@antipenko.pp.ua>",
+  "author": "Lutfi Dwica <dwicao.com@gmail.com> (https://dwicao.com/)",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/website-scraper/node-website-scraper/issues"


### PR DESCRIPTION
Hi, first of all, thank you so much for creating this useful package.

May I know the reason why would you forbid to save on an existing directory?

So I've been developing an app using AWS Lambda and It only allows me to write in /tmp/ directory, which is in this case it always exists.
If it's not bugging you, please consider this is as a new feature.

Have a nice day!