### PR TITLE
Add node 16 to Github Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
       - run: npm test
-      - name: Coveralls 
+      - name: Coveralls
         if: ${{ matrix.node-version == '14.x' }}
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
Node.js v16 is active LTS starting from 2021-10-26 accroding to https://nodejs.org/en/about/releases/