### PR TITLE
fix: non-english char encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,12 @@ Parameters - object which includes:
 
 Should return resolved `Promise` if resource should be saved or rejected with Error `Promise` if it should be skipped.
 Promise should be resolved with:
-* `string` which contains response body
-* or object with properties `body` (response body, string) and `metadata` - everything you want to save for this resource (like headers, original text, timestamps, etc.), scraper will not use this field at all, it is only for result.
+* the `response` object with the `body` modified in place as necessary.
+* or object with properties 
+  * `body` (response body, string)
+  * `encoding` (`binary` or `utf8`) used to save the file, binary used by default.
+  * `metadata` (object) - everything you want to save for this resource (like headers, original text, timestamps, etc.), scraper will not use this field at all, it is only for result.
+* a binary `string`. This is advised against because of the binary assumption being made can foul up saving of `utf8` responses to the filesystem. 
 
 If multiple actions `afterResponse` added - scraper will use result from last one.
 ```javascript
@@ -342,7 +346,8 @@ registerAction('afterResponse', ({response}) => {
 			metadata: {
 				headers: response.headers,
 				someOtherData: [ 1, 2, 3 ]
-			}
+			},
+      encoding: 'utf8'
 		}
 	}
 });

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -48,7 +48,7 @@ const config = {
 	],
 	request: {
 		throwHttpErrors: false,
-		encoding: 'binary',
+		responseType: 'buffer',
 		//cookieJar: true,
 		decompress: true,
 		headers: {

--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -20,7 +20,7 @@ class SaveResourceToFileSystemPlugin {
 		registerAction('saveResource', async ({resource}) => {
 			const filename = path.join(absoluteDirectoryPath, resource.getFilename());
 			const text = resource.getText();
-			await fs.outputFile(filename, text, { encoding: 'binary' });
+			await fs.outputFile(filename, text, { encoding: resource.getEncoding() });
 			loadedResources.push(resource);
 		});
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -7,20 +7,25 @@ function getMimeType (contentType) {
 }
 
 function defaultResponseHandler ({response}) {
-	return Promise.resolve(response.body);
+	return Promise.resolve(response);
 }
 
-function transformResult (result) {
+function transformResult (response) {
+	const encoding = response.headers?.['content-type']?.includes('utf-8') ? 'utf8' : 'binary';
+	const result = response.body.toString(encoding);
+
 	switch (true) {
 		case typeof result === 'string':
 			return {
 				body: result,
-				metadata: null
+				metadata: null,
+				encoding
 			};
 		case isPlainObject(result):
 			return {
 				body: result.body,
-				metadata: result.metadata || null
+				metadata: result.metadata || null,
+				encoding
 			};
 		case result === null:
 			return null;
@@ -50,7 +55,8 @@ async function getRequest ({url, referer, options = {}, afterResponse = defaultR
 		url: response.url,
 		mimeType: getMimeType(response.headers['content-type']),
 		body: responseHandlerResult.body,
-		metadata: responseHandlerResult.metadata
+		metadata: responseHandlerResult.metadata,
+		encoding: responseHandlerResult.encoding
 	};
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,6 +10,16 @@ function defaultResponseHandler ({response}) {
 	return Promise.resolve(response);
 }
 
+function getEncoding (response) {
+	if (response && typeof response.headers === 'object') {
+		const contentTypeHeader = response.headers['content-type'];
+
+		return contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
+	}
+
+	return 'binary';
+}
+
 /**
  * Normalizes the request response so to maintain compatibility with the old API
  * while adding the ability to extract the encoding information from the response.
@@ -19,15 +29,16 @@ function defaultResponseHandler ({response}) {
  */
 function normalizeResponse (response) {
 	let result = response;
-	let encoding = 'binary';
+	let encoding = getEncoding(response);
 
-	if (response && typeof response.headers === 'object' && typeof response.body !== 'undefined') {
-		const contentTypeHeader = response.headers['content-type'];
-
-		encoding = contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
-		result = response.body.toString(encoding);
+	if (response) {
+		if (response.body instanceof Buffer) {
+			result = response.body.toString(encoding);
+		} else {
+			result = response.body.toString();
+		}
 	} else if (response instanceof Buffer) {
-		result = response.toString('binary');
+		result = response.toString(encoding);
 	}
 
 	return {

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,7 +40,7 @@ function throwTypeError (result) {
 	throw new Error(`Wrong response handler result. Expected string or object, but received ${type}`);
 }
 
-function getData(result) {
+function getData (result) {
 	let data = result;
 	if (result && typeof result === 'object' && 'body' in result) {
 		data = result.body;

--- a/lib/request.js
+++ b/lib/request.js
@@ -11,10 +11,20 @@ function defaultResponseHandler ({response}) {
 }
 
 function transformResult (response) {
-	const encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
-	const result = response.body.toString(encoding);
+	// Response could be a response object or it could be a raw string/binary/whatever so we need to be safe and try
+	// to handle when it's not a response object.
+
+	let result = response;
+	let encoding = 'binary';
+
+	if (response && typeof response.headers === 'object' && typeof response.body !== 'undefined') {
+		encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
+		result = response.body.toString(encoding);
+	}
 
 	switch (true) {
+		case result === null:
+			return null;
 		case typeof result === 'string':
 			return {
 				body: result,
@@ -25,10 +35,8 @@ function transformResult (response) {
 			return {
 				body: result.body,
 				metadata: result.metadata || null,
-				encoding
+				encoding: result.encoding || encoding || 'binary'
 			};
-		case result === null:
-			return null;
 		default:
 			throw new Error('Wrong response handler result. Expected string or object, but received ' + typeof result);
 	}

--- a/lib/request.js
+++ b/lib/request.js
@@ -18,7 +18,9 @@ function normalizeResponse(response) {
 	let encoding = 'binary';
 
 	if (response && typeof response.headers === 'object' && typeof response.body !== 'undefined') {
-		encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
+		const contentTypeHeader = response.headers['content-type'];
+
+		encoding = contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
 		result = response.body.toString(encoding);
 	} else if (response instanceof Buffer) {
 		result = response.toString('binary');

--- a/lib/request.js
+++ b/lib/request.js
@@ -20,11 +20,11 @@ function transformResult (response) {
 	if (response && typeof response.headers === 'object' && typeof response.body !== 'undefined') {
 		encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
 		result = response.body.toString(encoding);
+	} else if (response instanceof Buffer) {
+		result = response.toString('binary');
 	}
 
 	switch (true) {
-		case result === null:
-			return null;
 		case typeof result === 'string':
 			return {
 				body: result,
@@ -37,6 +37,8 @@ function transformResult (response) {
 				metadata: result.metadata || null,
 				encoding: result.encoding || encoding || 'binary'
 			};
+		case result === null:
+			return null;			
 		default:
 			throw new Error('Wrong response handler result. Expected string or object, but received ' + typeof result);
 	}

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,7 +10,7 @@ function defaultResponseHandler ({response}) {
 	return Promise.resolve(response);
 }
 
-function transformResult (response) {
+function normalizeResponse(response) {
 	// Response could be a response object or it could be a raw string/binary/whatever so we need to be safe and try
 	// to handle when it's not a response object.
 
@@ -23,6 +23,15 @@ function transformResult (response) {
 	} else if (response instanceof Buffer) {
 		result = response.toString('binary');
 	}
+
+	return {
+		result, 
+		encoding
+	};
+}
+
+function transformResult (response) {
+	const {result, encoding} = normalizeResponse(response);
 
 	switch (true) {
 		case typeof result === 'string':

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,6 @@
 import got from 'got';
 import logger from './logger.js';
-import { extend, isPlainObject } from './utils/index.js';
+import { extend } from './utils/index.js';
 
 function getMimeType (contentType) {
 	return contentType ? contentType.split(';')[0] : null;
@@ -15,59 +15,51 @@ function getEncoding (response) {
 		const contentTypeHeader = response.headers['content-type'];
 
 		return contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
+	} else if (response && response.encoding) {
+		return response.encoding;
 	}
 
 	return 'binary';
 }
 
-/**
- * Normalizes the request response so to maintain compatibility with the old API
- * while adding the ability to extract the encoding information from the response.
- * 
- * @param response - Node Response, Buffer, string, or plain object.
- * @returns result and encoding.
- */
-function normalizeResponse (response) {
-	let result = response;
-	let encoding = getEncoding(response);
+function throwTypeError(result) {
+	let type = typeof result;
+	
+	if (result instanceof Error) {
+		throw result;
+	} else if (type === 'object' && Array.isArray(result)) {
+		type = 'array';
+	}
 
-	if (response) {
-		if (response.body instanceof Buffer) {
-			result = response.body.toString(encoding);
-		} else {
-			result = response.body.toString();
-		}
-	} else if (response instanceof Buffer) {
-		result = response.toString(encoding);
+	throw new Error(`Wrong response handler result. Expected string or object, but received ${type}`);
+}
+
+function transformResult (result) {
+	let encoding = getEncoding(result);
+
+	// First normalize down to find where the data should be.
+	let data = result;
+	if (result && typeof result === 'object' && 'body' in result) {
+		data = result.body;
+	}
+
+	// Then stringify it.
+	let body = null;
+	if (data instanceof Buffer) {
+		body = data.toString(encoding);
+	} else if (typeof data === 'string') {
+		body = data;
+	} else if (data === null || data === undefined) {
+		return null;
+	} else {
+		throwTypeError(result);
 	}
 
 	return {
-		result, 
-		encoding
+		body,
+		encoding,
+		metadata: result.metadata || data.metadata || null
 	};
-}
-
-function transformResult (response) {
-	const {result, encoding} = normalizeResponse(response);
-
-	switch (true) {
-		case typeof result === 'string':
-			return {
-				body: result,
-				metadata: null,
-				encoding
-			};
-		case isPlainObject(result):
-			return {
-				body: result.body,
-				metadata: result.metadata || null,
-				encoding: result.encoding || encoding || 'binary'
-			};
-		case result === null:
-			return null;			
-		default:
-			throw new Error('Wrong response handler result. Expected string or object, but received ' + typeof result);
-	}
 }
 
 async function getRequest ({url, referer, options = {}, afterResponse = defaultResponseHandler}) {
@@ -97,5 +89,7 @@ async function getRequest ({url, referer, options = {}, afterResponse = defaultR
 }
 
 export default {
-	get: getRequest
+	get: getRequest,
+	getEncoding,
+	transformResult
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,10 +10,14 @@ function defaultResponseHandler ({response}) {
 	return Promise.resolve(response);
 }
 
-function normalizeResponse(response) {
-	// Response could be a response object or it could be a raw string/binary/whatever so we need to be safe and try
-	// to handle when it's not a response object.
-
+/**
+ * Normalizes the request response so to maintain compatibility with the old API
+ * while adding the ability to extract the encoding information from the response.
+ * 
+ * @param response - Node Response, Buffer, string, or plain object.
+ * @returns result and encoding.
+ */
+function normalizeResponse (response) {
 	let result = response;
 	let encoding = 'binary';
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,21 +10,27 @@ function defaultResponseHandler ({response}) {
 	return Promise.resolve(response);
 }
 
-function getEncoding (response) {
-	if (response && typeof response.headers === 'object') {
-		const contentTypeHeader = response.headers['content-type'];
+function extractEncodingFromHeader (headers) {
+	const contentTypeHeader = headers['content-type'];
 
-		return contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
-	} else if (response && response.encoding) {
-		return response.encoding;
+	return contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
+}
+
+function getEncoding (response) {
+	if (typeof response === 'object') {
+		if (typeof response.headers === 'object') {
+			return extractEncodingFromHeader(response.headers);
+		} else if (response.encoding) {
+			return response.encoding;
+		}
 	}
 
 	return 'binary';
 }
 
-function throwTypeError(result) {
+function throwTypeError (result) {
 	let type = typeof result;
-	
+
 	if (result instanceof Error) {
 		throw result;
 	} else if (type === 'object' && Array.isArray(result)) {
@@ -43,14 +49,17 @@ function transformResult (result) {
 		data = result.body;
 	}
 
+	// Check for no data
+	if (data === null || data === undefined) {
+		return null;
+	}
+
 	// Then stringify it.
 	let body = null;
 	if (data instanceof Buffer) {
 		body = data.toString(encoding);
 	} else if (typeof data === 'string') {
 		body = data;
-	} else if (data === null || data === undefined) {
-		return null;
 	} else {
 		throwTypeError(result);
 	}

--- a/lib/request.js
+++ b/lib/request.js
@@ -17,8 +17,8 @@ function extractEncodingFromHeader (headers) {
 }
 
 function getEncoding (response) {
-	if (typeof response === 'object') {
-		if (typeof response.headers === 'object') {
+	if (response && typeof response === 'object') {
+		if (response.headers && typeof response.headers === 'object') {
 			return extractEncodingFromHeader(response.headers);
 		} else if (response.encoding) {
 			return response.encoding;

--- a/lib/request.js
+++ b/lib/request.js
@@ -11,7 +11,7 @@ function defaultResponseHandler ({response}) {
 }
 
 function transformResult (response) {
-	const encoding = response.headers?.['content-type']?.includes('utf-8') ? 'utf8' : 'binary';
+	const encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
 	const result = response.body.toString(encoding);
 
 	switch (true) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,14 +40,18 @@ function throwTypeError (result) {
 	throw new Error(`Wrong response handler result. Expected string or object, but received ${type}`);
 }
 
-function transformResult (result) {
-	let encoding = getEncoding(result);
-
-	// First normalize down to find where the data should be.
+function getData(result) {
 	let data = result;
 	if (result && typeof result === 'object' && 'body' in result) {
 		data = result.body;
 	}
+
+	return data;
+}
+
+function transformResult (result) {
+	const encoding = getEncoding(result);
+	const data = getData(result);
 
 	// Check for no data
 	if (data === null || data === undefined) {

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -12,6 +12,7 @@ class Resource {
 		this.children = [];
 
 		this.saved = false;
+		this.encoding = 'binary';
 	}
 
 	createChild (url, filename) {
@@ -67,6 +68,14 @@ class Resource {
 
 	getType () {
 		return this.type;
+	}
+
+	setEncoding (encoding) {
+		this.encoding = encoding;
+	}
+
+	getEncoding () {
+		return this.encoding;
 	}
 
 	isHtml () {

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -170,6 +170,7 @@ class Scraper {
 					self.requestedResourcePromises.set(responseData.url, requestPromise);
 				}
 
+				resource.setEncoding(responseData.encoding);
 				resource.setType(getTypeByMime(responseData.mimeType));
 
 				const { filename } = await self.runActions('generateFilename', { resource, responseData });

--- a/test/functional/encoding/mocks/index.html
+++ b/test/functional/encoding/mocks/index.html
@@ -8,5 +8,6 @@
     <div id="special-characters-korean">저는 7년 동안 한국에서 살았어요.</div>
     <div id="special-characters-ukrainian">Слава Україні!</div>
     <div id="special-characters-chinese">加入网站</div>
+    <div id="special-characters-ukrainian">Обладнання та ПЗ</div>
 </body>
 </html>

--- a/test/unit/request-test.js
+++ b/test/unit/request-test.js
@@ -144,3 +144,146 @@ describe('request', () => {
 		});
 	});
 });
+
+describe('get encoding', () => {
+	it('should return binary by default', () => {
+		const result = request.getEncoding(null);
+
+		should(result).be.eql('binary');
+	});
+
+	it('should return binary when no content-type header supplies', () => {
+		const result = request.getEncoding({
+			headers: {}
+		});
+
+		should(result).be.eql('binary');
+	});
+
+	it('should return binary when content type header doesn\'t include utf-8', () => {
+		const result = request.getEncoding({
+			headers: {}
+		});
+
+		should(result).be.eql('binary');
+	});
+
+	it('should return binary when content type header doesn\'t include utf-8', () => {
+		const result = request.getEncoding({
+			headers: {
+				'content-type': 'text/html'
+			}
+		});
+
+		should(result).be.eql('binary');
+	});
+
+	it('should return utf8 when content type includes utf-8', () => {
+		const result = request.getEncoding({
+			headers: {
+				'content-type': 'text/html; charset=utf-8'
+			}
+		});
+
+		should(result).be.eql('utf8');
+	});
+
+	it('should return utf8 response object includes it', () => {
+		const result = request.getEncoding({
+			encoding: 'utf8'
+		});
+
+		should(result).be.eql('utf8');
+	});
+});
+
+describe('transformResult', () => {
+	it('should throw with weird shaped response', () => {
+		try {
+			request.transformResult([1,2,3]);
+
+			// We shouldn't get here.
+			should(true).eql(false);
+		} catch (e) {
+			should(e).be.instanceOf(Error);
+			should(e.message).eql('Wrong response handler result. Expected string or object, but received array');
+		}
+	});
+
+	it('should pass through error', () => {
+		try {
+			request.transformResult(new Error('Oh no'));
+
+			// We shouldn't get here.
+			should(true).eql(false);
+		} catch (e) {
+			should(e).be.instanceOf(Error);
+			should(e.message).eql('Oh no');
+		}
+	});
+
+	it('should throw with boolean input', () => {
+		try {
+			request.transformResult(true);
+
+			// We shouldn't get here.
+			should(true).eql(false);
+		} catch (e) {
+			should(e).be.instanceOf(Error);
+			should(e.message).eql('Wrong response handler result. Expected string or object, but received boolean');
+		}
+	});
+
+	it('should handle object', () => {
+		const result = request.transformResult({
+			body: 'SOME BODY',
+			encoding: 'utf8',
+			metadata: { foo: 'bar' }
+		});
+
+		should(result).have.property('body', 'SOME BODY');
+		should(result).have.property('encoding', 'utf8');
+		should(result).have.property('metadata', { foo: 'bar' });
+	});
+
+	it('should handle object with empty body string', () => {
+		const result = request.transformResult({
+			body: '',
+			encoding: 'utf8',
+		});
+
+		should(result).have.property('body', '');
+		should(result).have.property('encoding', 'utf8');
+		should(result).have.property('metadata', null);
+	});
+
+	it('should handle object with defaults and buffer body', () => {
+		const result = request.transformResult({
+			body: Buffer.from('SOME BODY'),
+		});
+
+		should(result).have.property('body', 'SOME BODY');
+		should(result).have.property('encoding', 'binary');
+		should(result).have.property('metadata', null);
+	});
+
+	it('should handle raw string input', () => {
+		const result = request.transformResult('SOME BODY');
+
+		should(result).have.property('body', 'SOME BODY');
+		should(result).have.property('encoding', 'binary');
+		should(result).have.property('metadata', null);
+	});
+
+	it('should handle null input', () => {
+		const result = request.transformResult(null);
+
+		should(result).eqls(null);
+	});
+
+	it('should handle undefined input', () => {
+		const result = request.transformResult(undefined);
+
+		should(result).eqls(null);
+	});
+});

--- a/test/unit/request-test.js
+++ b/test/unit/request-test.js
@@ -66,12 +66,14 @@ describe('request', () => {
 			nock(url).get('/').reply(200, 'TEST BODY');
 			const handlerStub = sinon.stub().resolves({
 				body: 'a',
-				metadata: 'b'
+				metadata: 'b',
+				encoding: 'utf8'
 			});
 
 			return request.get({url, afterResponse: handlerStub}).then((data) => {
 				should(data.body).be.eql('a');
 				should(data.metadata).be.eql('b');
+				should(data.encoding).be.eql('utf8');
 			});
 		});
 
@@ -85,6 +87,7 @@ describe('request', () => {
 			return request.get({url, afterResponse: handlerStub}).then((data) => {
 				should(data.body).be.eql('a');
 				should(data.metadata).be.eql(null);
+				should(data.encoding).be.eql('binary');
 			});
 		});
 
@@ -124,6 +127,7 @@ describe('request', () => {
 			data.url.should.be.eql('http://www.google.com/');
 			data.body.should.be.eql('Hello from Google!');
 			data.mimeType.should.be.eql('text/html');
+			data.encoding.should.be.eql('utf8');
 		});
 	});
 
@@ -135,6 +139,7 @@ describe('request', () => {
 			data.should.have.properties(['url', 'body', 'mimeType']);
 			data.url.should.be.eql('http://www.google.com/');
 			data.body.should.be.eql('Hello from Google!');
+			data.encoding.should.be.eql('binary');
 			should(data.mimeType).be.eql(null);
 		});
 	});

--- a/test/unit/scraper-init-test.js
+++ b/test/unit/scraper-init-test.js
@@ -121,7 +121,7 @@ describe('Scraper initialization', function () {
 
 			s.options.request.should.containEql({
 				throwHttpErrors: false,
-				encoding: 'binary',
+				responseType: 'buffer',
 				decompress: true,
 				https: {
 					rejectUnauthorized: false
@@ -143,7 +143,7 @@ describe('Scraper initialization', function () {
 
 			s.options.request.should.eql({
 				throwHttpErrors: true,
-				encoding: 'binary',
+				responseType: 'buffer',
 				decompress: true,
 				https: {
 					rejectUnauthorized: false

--- a/test/unit/scraper-test.js
+++ b/test/unit/scraper-test.js
@@ -251,7 +251,7 @@ describe('Scraper', () => {
 
 			class AddMetadataPlugin {
 				apply (registerAction) {
-					registerAction('afterResponse', sinon.stub().returns({body: 'test body', metadata}));
+					registerAction('afterResponse', sinon.stub().returns({body: 'test body', metadata, encoding: 'utf8'}));
 				}
 			}
 
@@ -272,6 +272,7 @@ describe('Scraper', () => {
 			should(r.getUrl()).be.eql('http://example.com');
 			should(r.getType()).be.eql('html');
 			should(r.getFilename()).be.eql('generated-filename');
+			should(r.getEncoding()).be.eql('utf8');
 			should(r.metadata).be.eql(metadata);
 		});
 	});


### PR DESCRIPTION
This closes #454 and works in a nice generic way by passing through an encoding param which is used to save the file. This required some changes to the `afterResponse` API to allow it to work correctly however via `normalizeResponse` it will retain compatibility. Now I just need to fix-up the tests