### PR TITLE
feat: improve memory performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,12 @@ Parameters - object which includes:
 
 Should return resolved `Promise` if resource should be saved or rejected with Error `Promise` if it should be skipped.
 Promise should be resolved with:
-* `string` which contains response body
-* or object with properties `body` (response body, string) and `metadata` - everything you want to save for this resource (like headers, original text, timestamps, etc.), scraper will not use this field at all, it is only for result.
+* the `response` object with the `body` modified in place as necessary.
+* or object with properties 
+  * `body` (response body, string)
+  * `encoding` (`binary` or `utf8`) used to save the file, binary used by default.
+  * `metadata` (object) - everything you want to save for this resource (like headers, original text, timestamps, etc.), scraper will not use this field at all, it is only for result.
+* a binary `string`. This is advised against because of the binary assumption being made can foul up saving of `utf8` responses to the filesystem. 
 
 If multiple actions `afterResponse` added - scraper will use result from last one.
 ```javascript
@@ -342,7 +346,8 @@ registerAction('afterResponse', ({response}) => {
 			metadata: {
 				headers: response.headers,
 				someOtherData: [ 1, 2, 3 ]
-			}
+			},
+      encoding: 'utf8'
 		}
 	}
 });

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ If multiple actions `saveResource` added - resource will be saved to multiple st
 ```javascript
 registerAction('saveResource', async ({resource}) => {
   const filename = resource.getFilename();
-  const text = resource.getText();
+  const text = await resource.getText();
   await saveItSomewhere(filename, text);
 });
 ```

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ scrape(options).then((result) => {});
 * [urlFilter](#urlfilter) - skip some urls
 * [filenameGenerator](#filenamegenerator) - generate filename for downloaded resource
 * [requestConcurrency](#requestconcurrency) - set maximum concurrent requests
+* [tempMode](#tempMode) - How to store data temporarily during processing
 * [plugins](#plugins) - plugins, allow to customize filenames, request options, response handling, saving to storage, etc.
 
 Default options you can find in [lib/config/defaults.js](https://github.com/website-scraper/node-website-scraper/blob/master/lib/config/defaults.js) or get them using 
@@ -199,6 +200,13 @@ scrape({
 #### requestConcurrency
 Number, maximum amount of concurrent requests. Defaults to `Infinity`.
 
+#### tempMode
+
+How to store temporary data when processing
+
+* `memory` - Data is store in memory in its raw format (default).
+* `memory-compressed` - Data is stored in memory but compressed using zlib. This is more memory efficient at the expense of CPU time spend compressing and decompressing.
+* `fs` / `filesystem` - Data is stored in temporary files on the filesystem. This is the most memory efficient but it is strongly recommended to only use this mode with a solid state drive.
 
 #### plugins
 

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -48,7 +48,7 @@ const config = {
 	],
 	request: {
 		throwHttpErrors: false,
-		encoding: 'binary',
+		responseType: 'buffer',
 		//cookieJar: true,
 		decompress: true,
 		headers: {

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -63,7 +63,8 @@ const config = {
 	recursive: false,
 	maxRecursiveDepth: null,
 	maxDepth: null,
-	ignoreErrors: false
+	ignoreErrors: false,
+	tempMode: 'memory' // 'memory-compressed', 'fs'
 };
 
 export default config;

--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -20,7 +20,7 @@ class SaveResourceToFileSystemPlugin {
 		registerAction('saveResource', async ({resource}) => {
 			const filename = path.join(absoluteDirectoryPath, resource.getFilename());
 			const text = resource.getText();
-			await fs.outputFile(filename, text, { encoding: 'binary' });
+			await fs.outputFile(filename, text, { encoding: resource.getEncoding() });
 			loadedResources.push(resource);
 		});
 

--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -1,32 +1,45 @@
 import path from 'path';
-import fs from 'fs-extra';
+import { promises as fs } from 'fs';
 
 class SaveResourceToFileSystemPlugin {
 	apply (registerAction) {
 		let absoluteDirectoryPath, loadedResources = [];
 
-		registerAction('beforeStart', ({options}) => {
+		registerAction('beforeStart', async ({options}) => {
 			if (!options.directory || typeof options.directory !== 'string') {
 				throw new Error(`Incorrect directory ${options.directory}`);
 			}
 
 			absoluteDirectoryPath = path.resolve(process.cwd(), options.directory);
 
-			if (fs.existsSync(absoluteDirectoryPath)) {
+			let exists = false;
+			try {
+				await fs.stat(absoluteDirectoryPath);
+				exists = true;
+			} catch (err) {
+				// lstat throws an error if the directory doesn't exist. 
+				// We don't care about that error because we don't want that
+				// directory to exist. 
+			}
+
+			if (exists) {
 				throw new Error(`Directory ${absoluteDirectoryPath} exists`);
 			}
 		});
 
 		registerAction('saveResource', async ({resource}) => {
 			const filename = path.join(absoluteDirectoryPath, resource.getFilename());
-			const text = resource.getText();
-			await fs.outputFile(filename, text, { encoding: resource.getEncoding() });
+			await fs.mkdir(path.dirname(filename), { recursive: true });
+
+			const text = await resource.getText();
+
+			await fs.writeFile(filename, text, { encoding: resource.getEncoding() });
 			loadedResources.push(resource);
 		});
 
 		registerAction('error', async () => {
 			if (loadedResources.length > 0) {
-				await fs.remove(absoluteDirectoryPath);
+				await fs.rm(absoluteDirectoryPath, { recursive: true, force: true });
 			}
 		});
 	}

--- a/lib/request.js
+++ b/lib/request.js
@@ -7,20 +7,25 @@ function getMimeType (contentType) {
 }
 
 function defaultResponseHandler ({response}) {
-	return Promise.resolve(response.body);
+	return Promise.resolve(response);
 }
 
-function transformResult (result) {
+function transformResult (response) {
+	const encoding = response.headers?.['content-type']?.includes('utf-8') ? 'utf8' : 'binary';
+	const result = response.body.toString(encoding);
+
 	switch (true) {
 		case typeof result === 'string':
 			return {
 				body: result,
-				metadata: null
+				metadata: null,
+				encoding
 			};
 		case isPlainObject(result):
 			return {
 				body: result.body,
-				metadata: result.metadata || null
+				metadata: result.metadata || null,
+				encoding
 			};
 		case result === null:
 			return null;
@@ -50,7 +55,8 @@ async function getRequest ({url, referer, options = {}, afterResponse = defaultR
 		url: response.url,
 		mimeType: getMimeType(response.headers['content-type']),
 		body: responseHandlerResult.body,
-		metadata: responseHandlerResult.metadata
+		metadata: responseHandlerResult.metadata,
+		encoding: responseHandlerResult.encoding
 	};
 }
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,6 +10,16 @@ function defaultResponseHandler ({response}) {
 	return Promise.resolve(response);
 }
 
+function getEncoding (response) {
+	if (response && typeof response.headers === 'object') {
+		const contentTypeHeader = response.headers['content-type'];
+
+		return contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
+	}
+
+	return 'binary';
+}
+
 /**
  * Normalizes the request response so to maintain compatibility with the old API
  * while adding the ability to extract the encoding information from the response.
@@ -19,15 +29,16 @@ function defaultResponseHandler ({response}) {
  */
 function normalizeResponse (response) {
 	let result = response;
-	let encoding = 'binary';
+	let encoding = getEncoding(response);
 
-	if (response && typeof response.headers === 'object' && typeof response.body !== 'undefined') {
-		const contentTypeHeader = response.headers['content-type'];
-
-		encoding = contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
-		result = response.body.toString(encoding);
+	if (response) {
+		if (response.body instanceof Buffer) {
+			result = response.body.toString(encoding);
+		} else {
+			result = response.body.toString();
+		}
 	} else if (response instanceof Buffer) {
-		result = response.toString('binary');
+		result = response.toString(encoding);
 	}
 
 	return {

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,7 +40,7 @@ function throwTypeError (result) {
 	throw new Error(`Wrong response handler result. Expected string or object, but received ${type}`);
 }
 
-function getData(result) {
+function getData (result) {
 	let data = result;
 	if (result && typeof result === 'object' && 'body' in result) {
 		data = result.body;

--- a/lib/request.js
+++ b/lib/request.js
@@ -11,10 +11,20 @@ function defaultResponseHandler ({response}) {
 }
 
 function transformResult (response) {
-	const encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
-	const result = response.body.toString(encoding);
+	// Response could be a response object or it could be a raw string/binary/whatever so we need to be safe and try
+	// to handle when it's not a response object.
+
+	let result = response;
+	let encoding = 'binary';
+
+	if (response && typeof response.headers === 'object' && typeof response.body !== 'undefined') {
+		encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
+		result = response.body.toString(encoding);
+	}
 
 	switch (true) {
+		case result === null:
+			return null;
 		case typeof result === 'string':
 			return {
 				body: result,
@@ -25,10 +35,8 @@ function transformResult (response) {
 			return {
 				body: result.body,
 				metadata: result.metadata || null,
-				encoding
+				encoding: result.encoding || encoding || 'binary'
 			};
-		case result === null:
-			return null;
 		default:
 			throw new Error('Wrong response handler result. Expected string or object, but received ' + typeof result);
 	}

--- a/lib/request.js
+++ b/lib/request.js
@@ -18,7 +18,9 @@ function normalizeResponse(response) {
 	let encoding = 'binary';
 
 	if (response && typeof response.headers === 'object' && typeof response.body !== 'undefined') {
-		encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
+		const contentTypeHeader = response.headers['content-type'];
+
+		encoding = contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
 		result = response.body.toString(encoding);
 	} else if (response instanceof Buffer) {
 		result = response.toString('binary');

--- a/lib/request.js
+++ b/lib/request.js
@@ -20,11 +20,11 @@ function transformResult (response) {
 	if (response && typeof response.headers === 'object' && typeof response.body !== 'undefined') {
 		encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
 		result = response.body.toString(encoding);
+	} else if (response instanceof Buffer) {
+		result = response.toString('binary');
 	}
 
 	switch (true) {
-		case result === null:
-			return null;
 		case typeof result === 'string':
 			return {
 				body: result,
@@ -37,6 +37,8 @@ function transformResult (response) {
 				metadata: result.metadata || null,
 				encoding: result.encoding || encoding || 'binary'
 			};
+		case result === null:
+			return null;			
 		default:
 			throw new Error('Wrong response handler result. Expected string or object, but received ' + typeof result);
 	}

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,7 +10,7 @@ function defaultResponseHandler ({response}) {
 	return Promise.resolve(response);
 }
 
-function transformResult (response) {
+function normalizeResponse(response) {
 	// Response could be a response object or it could be a raw string/binary/whatever so we need to be safe and try
 	// to handle when it's not a response object.
 
@@ -23,6 +23,15 @@ function transformResult (response) {
 	} else if (response instanceof Buffer) {
 		result = response.toString('binary');
 	}
+
+	return {
+		result, 
+		encoding
+	};
+}
+
+function transformResult (response) {
+	const {result, encoding} = normalizeResponse(response);
 
 	switch (true) {
 		case typeof result === 'string':

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,6 @@
 import got from 'got';
 import logger from './logger.js';
-import { extend, isPlainObject } from './utils/index.js';
+import { extend } from './utils/index.js';
 
 function getMimeType (contentType) {
 	return contentType ? contentType.split(';')[0] : null;
@@ -15,59 +15,51 @@ function getEncoding (response) {
 		const contentTypeHeader = response.headers['content-type'];
 
 		return contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
+	} else if (response && response.encoding) {
+		return response.encoding;
 	}
 
 	return 'binary';
 }
 
-/**
- * Normalizes the request response so to maintain compatibility with the old API
- * while adding the ability to extract the encoding information from the response.
- * 
- * @param response - Node Response, Buffer, string, or plain object.
- * @returns result and encoding.
- */
-function normalizeResponse (response) {
-	let result = response;
-	let encoding = getEncoding(response);
+function throwTypeError(result) {
+	let type = typeof result;
+	
+	if (result instanceof Error) {
+		throw result;
+	} else if (type === 'object' && Array.isArray(result)) {
+		type = 'array';
+	}
 
-	if (response) {
-		if (response.body instanceof Buffer) {
-			result = response.body.toString(encoding);
-		} else {
-			result = response.body.toString();
-		}
-	} else if (response instanceof Buffer) {
-		result = response.toString(encoding);
+	throw new Error(`Wrong response handler result. Expected string or object, but received ${type}`);
+}
+
+function transformResult (result) {
+	let encoding = getEncoding(result);
+
+	// First normalize down to find where the data should be.
+	let data = result;
+	if (result && typeof result === 'object' && 'body' in result) {
+		data = result.body;
+	}
+
+	// Then stringify it.
+	let body = null;
+	if (data instanceof Buffer) {
+		body = data.toString(encoding);
+	} else if (typeof data === 'string') {
+		body = data;
+	} else if (data === null || data === undefined) {
+		return null;
+	} else {
+		throwTypeError(result);
 	}
 
 	return {
-		result, 
-		encoding
+		body,
+		encoding,
+		metadata: result.metadata || data.metadata || null
 	};
-}
-
-function transformResult (response) {
-	const {result, encoding} = normalizeResponse(response);
-
-	switch (true) {
-		case typeof result === 'string':
-			return {
-				body: result,
-				metadata: null,
-				encoding
-			};
-		case isPlainObject(result):
-			return {
-				body: result.body,
-				metadata: result.metadata || null,
-				encoding: result.encoding || encoding || 'binary'
-			};
-		case result === null:
-			return null;			
-		default:
-			throw new Error('Wrong response handler result. Expected string or object, but received ' + typeof result);
-	}
 }
 
 async function getRequest ({url, referer, options = {}, afterResponse = defaultResponseHandler}) {
@@ -97,5 +89,7 @@ async function getRequest ({url, referer, options = {}, afterResponse = defaultR
 }
 
 export default {
-	get: getRequest
+	get: getRequest,
+	getEncoding,
+	transformResult
 };

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,10 +10,14 @@ function defaultResponseHandler ({response}) {
 	return Promise.resolve(response);
 }
 
-function normalizeResponse(response) {
-	// Response could be a response object or it could be a raw string/binary/whatever so we need to be safe and try
-	// to handle when it's not a response object.
-
+/**
+ * Normalizes the request response so to maintain compatibility with the old API
+ * while adding the ability to extract the encoding information from the response.
+ * 
+ * @param response - Node Response, Buffer, string, or plain object.
+ * @returns result and encoding.
+ */
+function normalizeResponse (response) {
 	let result = response;
 	let encoding = 'binary';
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,21 +10,27 @@ function defaultResponseHandler ({response}) {
 	return Promise.resolve(response);
 }
 
-function getEncoding (response) {
-	if (response && typeof response.headers === 'object') {
-		const contentTypeHeader = response.headers['content-type'];
+function extractEncodingFromHeader (headers) {
+	const contentTypeHeader = headers['content-type'];
 
-		return contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
-	} else if (response && response.encoding) {
-		return response.encoding;
+	return contentTypeHeader && contentTypeHeader.includes('utf-8') ? 'utf8' : 'binary';
+}
+
+function getEncoding (response) {
+	if (typeof response === 'object') {
+		if (typeof response.headers === 'object') {
+			return extractEncodingFromHeader(response.headers);
+		} else if (response.encoding) {
+			return response.encoding;
+		}
 	}
 
 	return 'binary';
 }
 
-function throwTypeError(result) {
+function throwTypeError (result) {
 	let type = typeof result;
-	
+
 	if (result instanceof Error) {
 		throw result;
 	} else if (type === 'object' && Array.isArray(result)) {
@@ -43,14 +49,17 @@ function transformResult (result) {
 		data = result.body;
 	}
 
+	// Check for no data
+	if (data === null || data === undefined) {
+		return null;
+	}
+
 	// Then stringify it.
 	let body = null;
 	if (data instanceof Buffer) {
 		body = data.toString(encoding);
 	} else if (typeof data === 'string') {
 		body = data;
-	} else if (data === null || data === undefined) {
-		return null;
 	} else {
 		throwTypeError(result);
 	}

--- a/lib/request.js
+++ b/lib/request.js
@@ -17,8 +17,8 @@ function extractEncodingFromHeader (headers) {
 }
 
 function getEncoding (response) {
-	if (typeof response === 'object') {
-		if (typeof response.headers === 'object') {
+	if (response && typeof response === 'object') {
+		if (response.headers && typeof response.headers === 'object') {
 			return extractEncodingFromHeader(response.headers);
 		} else if (response.encoding) {
 			return response.encoding;

--- a/lib/request.js
+++ b/lib/request.js
@@ -11,7 +11,7 @@ function defaultResponseHandler ({response}) {
 }
 
 function transformResult (response) {
-	const encoding = response.headers?.['content-type']?.includes('utf-8') ? 'utf8' : 'binary';
+	const encoding = response.headers['content-type'] && response.headers['content-type'].includes('utf-8') ? 'utf8' : 'binary';
 	const result = response.body.toString(encoding);
 
 	switch (true) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -40,14 +40,18 @@ function throwTypeError (result) {
 	throw new Error(`Wrong response handler result. Expected string or object, but received ${type}`);
 }
 
-function transformResult (result) {
-	let encoding = getEncoding(result);
-
-	// First normalize down to find where the data should be.
+function getData(result) {
 	let data = result;
 	if (result && typeof result === 'object' && 'body' in result) {
 		data = result.body;
 	}
+
+	return data;
+}
+
+function transformResult (result) {
+	const encoding = getEncoding(result);
+	const data = getData(result);
 
 	// Check for no data
 	if (data === null || data === undefined) {

--- a/lib/resource-handler/css/index.js
+++ b/lib/resource-handler/css/index.js
@@ -7,12 +7,13 @@ class CssResourceHandler {
 		this.updateMissingSources = this.options.updateMissingSources === true || Array.isArray(this.options.updateMissingSources);
 	}
 
-	handle (resource) {
-		const pathContainer = new CssText(resource.getText());
-		return this.downloadChildrenPaths(pathContainer, resource, this.updateMissingSources).then(function updateText (updatedText) {
-			resource.setText(updatedText);
-			return resource;
-		});
+	async handle (resource) {
+		const pathContainer = new CssText(await resource.getText());
+
+		const updatedText = await this.downloadChildrenPaths(pathContainer, resource, this.updateMissingSources);
+		await resource.setText(updatedText);
+		
+		return resource;
 	}
 }
 

--- a/lib/resource-handler/html/index.js
+++ b/lib/resource-handler/html/index.js
@@ -23,7 +23,7 @@ class HtmlResourceHandler {
 	}
 
 	async handle (resource) {
-		const $ = loadTextToCheerio(resource.getText());
+		const $ = loadTextToCheerio(await resource.getText());
 		prepareToLoad($, resource);
 
 		const sourceRulesLoadPromises = this.allSources.map(
@@ -31,7 +31,7 @@ class HtmlResourceHandler {
 		);
 		await series(sourceRulesLoadPromises);
 
-		resource.setText($.html());
+		await resource.setText($.html());
 		return resource;
 	}
 

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -12,6 +12,7 @@ class Resource {
 		this.children = [];
 
 		this.saved = false;
+		this.encoding = 'binary';
 	}
 
 	createChild (url, filename) {
@@ -67,6 +68,14 @@ class Resource {
 
 	getType () {
 		return this.type;
+	}
+
+	setEncoding (encoding) {
+		this.encoding = encoding;
+	}
+
+	getEncoding () {
+		return this.encoding;
 	}
 
 	isHtml () {

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -4,19 +4,20 @@ import { promisify } from 'util';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 
 const inflate = promisify(zlib.inflate);
 const defalate = promisify(zlib.deflate);
 
 class Resource {
-	constructor (url, filename, tmpMode, tmpPath) {
+	constructor (url, filename, tmpMode, tmpDir) {
+		this.tmpMode = tmpMode || 'memory';
+		if (tmpMode === 'fs' || tmpMode === 'filesystem') {
+			this.tmpDir = tmpDir || fs.mkdtempSync(path.join(os.tmpdir(), 'website-scraper-'));
+		}
+
 		this.setUrl(url);
 		this.setFilename(filename);
-
-		this.tmpMode = tmpMode || 'memory';
-		if (tmpMode === 'filesystem') {
-			this.tmpPath = tmpPath || fs.mkdtempSync('website-scraper-');
-		}
 
 		this.type = null;
 		this.depth = 0;
@@ -29,7 +30,7 @@ class Resource {
 	}
 
 	createChild (url, filename) {
-		const child = new Resource(url, filename, this.tmpMode, this.tmpPath);
+		const child = new Resource(url, filename, this.tmpMode, this.tmpDir);
 		let currentDepth = this.getDepth();
 
 		child.parent = this;
@@ -52,10 +53,10 @@ class Resource {
 	}
 
 	setUrl (url) {
-		if (this.tmpPath) {
+		if (this.tmpDir) {
 			// Generate a unique filename based on the md5 hash of the url
 			const tmpName = `${crypto.createHash('md5').update(url).digest('hex')}.txt`;
-			this.tmpPath = path.join(this.tmpPath, tmpName);
+			this.tmpPath = path.join(this.tmpDir, tmpName);
 		}
 
 		this.url = url;
@@ -69,29 +70,29 @@ class Resource {
 		this.filename = filename;
 	}
 
-	getText () {
+	async getText () {
 		switch (this.tmpMode) {
 			case 'memory':
-				return this.memoryRead();
+				return await this._memoryRead();
 			case 'memory-compressed':
-				return this.memoryReadCompressed();
+				return await this._memoryReadCompressed();
 			case 'fs':
 			case 'filesystem':
-				return this.fsRead();
+				return await this._fsRead();
 			default:
 				throw new Error('Unknown tmpMode');
 		}
 	}
 
-	setText (text) {
+	async setText (text) {
 		switch (this.tmpMode) {
 			case 'memory':
-				return this.memoryWrite(text);
+				return await this._memoryWrite(text);
 			case 'memory-compressed':
-				return this.memoryWriteCompressed(text);
+				return await this._memoryWriteCompressed(text);
 			case 'fs':
 			case 'filesystem':
-				return this.fsWrite(text);
+				return await this._fsWrite(text);
 			default:
 				throw new Error('Unknown tmpMode');
 		}
@@ -143,28 +144,28 @@ class Resource {
 
 	// Read/write functions
 	// memory
-	async memoryRead () {
+	async _memoryRead () {
 		return this.text;
 	}
-	async memoryWrite (text) {
+	async _memoryWrite (text) {
 		this.text = text;
 	}
 
 	// memory-compressed
 	// When compressed store data in memory as a buffer, saves the toString/Buffer.from step every-time. 
-	async memoryReadCompressed () {
-		return inflate(this.text).toString(this.getEncoding());
+	async _memoryReadCompressed () {
+		return (await inflate(this.text)).toString(this.getEncoding());
 	}
-	async memoryWriteCompressed (text) {
-		this.text = defalate(Buffer.from(text), { level: 6 });
+	async _memoryWriteCompressed (text) {
+		this.text = await defalate(Buffer.from(text), { level: 6 });
 	}
 
 	// FS
-	async fsRead () {
-		return fs.promises.readFile(this.tmpPath, { encoding: this.getEncoding() });
+	async _fsRead () {
+		return await fs.promises.readFile(this.tmpPath, { encoding: this.getEncoding() });
 	}
-	async fsWrite (text) {
-		return fs.promises.writeFile(this.tmpPath, text, { encoding: this.getEncoding() });
+	async _fsWrite (text) {
+		await fs.promises.writeFile(this.tmpPath, text, { encoding: this.getEncoding() });
 	}
 }
 

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1,9 +1,22 @@
 import types from './config/resource-types.js';
+import zlib from 'zlib';
+import { promisify } from 'util';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+const inflate = promisify(zlib.inflate);
+const defalate = promisify(zlib.deflate);
 
 class Resource {
-	constructor (url, filename) {
-		this.url = url;
-		this.filename = filename;
+	constructor (url, filename, tmpMode, tmpPath) {
+		this.setUrl(url);
+		this.setFilename(filename);
+
+		this.tmpMode = tmpMode || 'memory';
+		if (tmpMode === 'filesystem') {
+			this.tmpPath = tmpPath || fs.mkdtempSync('website-scraper-');
+		}
 
 		this.type = null;
 		this.depth = 0;
@@ -16,7 +29,7 @@ class Resource {
 	}
 
 	createChild (url, filename) {
-		const child = new Resource(url, filename);
+		const child = new Resource(url, filename, this.tmpMode, this.tmpPath);
 		let currentDepth = this.getDepth();
 
 		child.parent = this;
@@ -39,6 +52,12 @@ class Resource {
 	}
 
 	setUrl (url) {
+		if (this.tmpPath) {
+			// Generate a unique filename based on the md5 hash of the url
+			const tmpName = `${crypto.createHash('md5').update(url).digest('hex')}.txt`;
+			this.tmpPath = path.join(this.tmpPath, tmpName);
+		}
+
 		this.url = url;
 	}
 
@@ -51,11 +70,31 @@ class Resource {
 	}
 
 	getText () {
-		return this.text;
+		switch (this.tmpMode) {
+			case 'memory':
+				return this.memoryRead();
+			case 'memory-compressed':
+				return this.memoryReadCompressed();
+			case 'fs':
+			case 'filesystem':
+				return this.fsRead();
+			default:
+				throw new Error('Unknown tmpMode');
+		}
 	}
 
 	setText (text) {
-		this.text = text;
+		switch (this.tmpMode) {
+			case 'memory':
+				return this.memoryWrite(text);
+			case 'memory-compressed':
+				return this.memoryWriteCompressed(text);
+			case 'fs':
+			case 'filesystem':
+				return this.fsWrite(text);
+			default:
+				throw new Error('Unknown tmpMode');
+		}
 	}
 
 	getDepth () {
@@ -100,6 +139,32 @@ class Resource {
 
 	setMetadata (metadata) {
 		this.metadata = metadata;
+	}
+
+	// Read/write functions
+	// memory
+	async memoryRead () {
+		return this.text;
+	}
+	async memoryWrite (text) {
+		this.text = text;
+	}
+
+	// memory-compressed
+	// When compressed store data in memory as a buffer, saves the toString/Buffer.from step every-time. 
+	async memoryReadCompressed () {
+		return inflate(this.text).toString(this.getEncoding());
+	}
+	async memoryWriteCompressed (text) {
+		this.text = defalate(Buffer.from(text), { level: 6 });
+	}
+
+	// FS
+	async fsRead () {
+		return fs.promises.readFile(this.tmpPath, { encoding: this.getEncoding() });
+	}
+	async fsWrite (text) {
+		return fs.promises.writeFile(this.tmpPath, text, { encoding: this.getEncoding() });
 	}
 }
 

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -170,6 +170,7 @@ class Scraper {
 					self.requestedResourcePromises.set(responseData.url, requestPromise);
 				}
 
+				resource.setEncoding(responseData.encoding);
 				resource.setType(getTypeByMime(responseData.mimeType));
 
 				const { filename } = await self.runActions('generateFilename', { resource, responseData });

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -47,7 +47,7 @@ class Scraper {
 			requestResource: this.requestResource.bind(this),
 			getReference: this.runActions.bind(this, 'getReference')
 		});
-		this.resources = this.options.urls.map(({url, filename}) => new Resource(url, filename));
+		this.resources = this.options.urls.map(({url, filename}) => new Resource(url, filename, this.options.tmpMode));
 
 		this.requestedResourcePromises = new NormalizedUrlMap(); // Map url -> request promise
 		this.loadedResources = new NormalizedUrlMap(); // Map url -> resource
@@ -185,7 +185,8 @@ class Scraper {
 					resource.setMetadata(responseData.metadata);
 				}
 
-				resource.setText(responseData.body);
+				await resource.setText(responseData.body);
+				
 				self.loadResource(resource); // Add resource to list for future downloading, see Scraper.waitForLoad
 				return resource;
 			}).catch(function handleError (err) {

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
     "cheerio": "1.0.0-rc.11",
     "css-url-parser": "^1.0.0",
     "debug": "^4.3.1",
-    "fs-extra": "^10.0.0",
     "got": "^12.0.0",
     "lodash": "^4.17.21",
     "normalize-url": "^7.0.2",
     "p-queue": "^7.1.0",
     "sanitize-filename": "^1.6.3",
-    "srcset": "^5.0.0"
+    "srcset": "^5.0.0",
+    "zlib": "^1.0.5"
   },
   "devDependencies": {
     "c8": "^7.7.2",

--- a/test/e2e/e2e-test.js
+++ b/test/e2e/e2e-test.js
@@ -1,20 +1,20 @@
 import 'should';
 import scrape from 'website-scraper';
-import fs from 'fs-extra';
 import _ from 'lodash';
+import fs from 'fs/promises';
 
-import { readFile } from 'fs/promises';
-const urls = JSON.parse(await readFile(new URL('./urls.json', import.meta.url)));
-const options = JSON.parse(await readFile(new URL('./options.json', import.meta.url)));
+const urls = JSON.parse(await fs.readFile(new URL('./urls.json', import.meta.url)));
+const options = JSON.parse(await fs.readFile(new URL('./options.json', import.meta.url)));
 
 const resultDirname = './test/e2e/results';
 
 describe('E2E', function() {
-	before(function() {
-		fs.emptyDirSync(resultDirname);
+	before(async () => {
+		await fs.rm(resultDirname, { recursive: true, force: true });
+		await fs.mkdir(resultDirname, { recursive: true });
 	});
 
-	after(function() {
+	after(() => {
 		console.log('Scraping completed. Go to ' + resultDirname + ' to check results');
 	});
 

--- a/test/functional/base/base.test.js
+++ b/test/functional/base/base.test.js
@@ -1,8 +1,8 @@
 import should from 'should';
 import '../../utils/assertions.js';
 import nock from 'nock';
-import fs from 'fs-extra';
-import cheerio from 'cheerio';
+import fs from 'fs/promises';
+import * as cheerio from 'cheerio';
 import scrape from 'website-scraper';
 import Resource from '../../../lib/resource.js';
 
@@ -32,15 +32,15 @@ describe('Functional: base', function() {
 		ignoreErrors: false
 	};
 
-	beforeEach(function() {
+	beforeEach(() => {
 		nock.cleanAll();
 		nock.disableNetConnect();
 	});
 
-	afterEach(function() {
+	afterEach(async () => {
 		nock.cleanAll();
 		nock.enableNetConnect();
-		fs.removeSync(testDirname);
+		await fs.rm(testDirname, { recursive: true, force: true });
 	});
 
 	beforeEach(() => {
@@ -67,147 +67,146 @@ describe('Functional: base', function() {
 		nock('http://blog.example.com/').get('/files/fail-1.png').replyWithError('something awful happened');
 	});
 
-	it('should load multiple urls to single directory with all specified sources', () => {
-		return scrape(options).then(function(result) {
-			// should return right result
-			result.should.be.instanceOf(Array).and.have.length(3);
+	it('should load multiple urls to single directory with all specified sources', async() => {
+		const result = await scrape(options);
+		// should return right result
+		result.should.be.instanceOf(Array).and.have.length(3);
 
-			result[0].should.have.properties({ url: 'http://example.com/', filename: 'index.html' });
-			result[0].should.have.properties('children');
-			result[0].children.should.be.instanceOf(Array).and.have.length(4);
-			result[0].children[0].should.be.instanceOf(Resource);
+		result[0].should.have.properties({ url: 'http://example.com/', filename: 'index.html' });
+		result[0].should.have.properties('children');
+		result[0].children.should.be.instanceOf(Array).and.have.length(4);
+		result[0].children[0].should.be.instanceOf(Resource);
 
-			result[1].should.have.properties({ url: 'http://example.com/about', filename: 'about.html' });
-			result[1].should.have.properties('children');
-			result[1].children.should.be.instanceOf(Array).and.have.length(4);
-			result[1].children[0].should.be.instanceOf(Resource);
+		result[1].should.have.properties({ url: 'http://example.com/about', filename: 'about.html' });
+		result[1].should.have.properties('children');
+		result[1].children.should.be.instanceOf(Array).and.have.length(4);
+		result[1].children[0].should.be.instanceOf(Resource);
 
-			result[2].should.have.properties({ url: 'http://blog.example.com/', filename: 'blog.html' }); // url after redirect
-			result[2].should.have.properties('children');
-			result[2].children.should.be.instanceOf(Array).and.have.length(1);
-			result[2].children[0].should.be.instanceOf(Resource);
+		result[2].should.have.properties({ url: 'http://blog.example.com/', filename: 'blog.html' }); // url after redirect
+		result[2].should.have.properties('children');
+		result[2].children.should.be.instanceOf(Array).and.have.length(1);
+		result[2].children[0].should.be.instanceOf(Resource);
 
-			// should create directory and subdirectories
-			fs.existsSync(testDirname).should.be.eql(true);
-			fs.existsSync(testDirname + '/img').should.be.eql(true);
-			fs.existsSync(testDirname + '/js').should.be.eql(true);
-			fs.existsSync(testDirname + '/css').should.be.eql(true);
+		// should create directory and subdirectories
+		await `${testDirname}`.should.dirExists(true);
+		await `${testDirname}/img`.should.dirExists(true);
+		await `${testDirname}/js`.should.dirExists(true);
+		await `${testDirname}/css`.should.dirExists(true);
 
-			// should contain all sources found in index.html
-			fs.existsSync(testDirname + '/css/index.css').should.be.eql(true);
-			fs.existsSync(testDirname + '/img/background.png').should.be.eql(true);
-			fs.existsSync(testDirname + '/img/cat.jpg').should.be.eql(true);
-			fs.existsSync(testDirname + '/js/script.min.js').should.be.eql(true);
+		// should contain all sources found in index.html
+		await `${testDirname}/css/index.css`.should.fileExists(true);
+		await `${testDirname}/img/background.png`.should.fileExists(true);
+		await `${testDirname}/img/cat.jpg`.should.fileExists(true);
+		await `${testDirname}/js/script.min.js`.should.fileExists(true);
 
-			// all sources in index.html should be replaced with local paths
-			let $ = cheerio.load(fs.readFileSync(testDirname + '/index.html').toString());
-			$('link[rel="stylesheet"]').attr('href').should.be.eql('css/index.css');
-			$('style').html().should.containEql('img/background.png');
-			$('img').attr('src').should.be.eql('img/cat.jpg');
-			$('script').attr('src').should.be.eql('js/script.min.js');
+		// all sources in index.html should be replaced with local paths
+		let $ = cheerio.load(await fs.readFile(testDirname + '/index.html', { encoding: 'binary' }));
+		$('link[rel="stylesheet"]').attr('href').should.be.eql('css/index.css');
+		$('style').html().should.containEql('img/background.png');
+		$('img').attr('src').should.be.eql('img/cat.jpg');
+		$('script').attr('src').should.be.eql('js/script.min.js');
 
-			// should contain all sources found in index.css recursively
-			fs.existsSync(testDirname + '/css/index-import-1.css').should.be.eql(true);
-			fs.existsSync(testDirname + '/css/index-import-2.css').should.be.eql(true);
-			fs.existsSync(testDirname + '/css/index-import-3.css').should.be.eql(true);
-			fs.existsSync(testDirname + '/img/index-image-1.png').should.be.eql(true);
-			fs.existsSync(testDirname + '/img/index-image-2.png').should.be.eql(true);
+		// should contain all sources found in index.css recursively
+		await `${testDirname}/css/index-import-1.css`.should.fileExists(true);
+		await `${testDirname}/css/index-import-2.css`.should.fileExists(true);
+		await `${testDirname}/css/index-import-3.css`.should.fileExists(true);
 
-			// all sources in index.css should be replaces with local files recursively
-			const indexCss = fs.readFileSync(testDirname + '/css/index.css').toString();
-			indexCss.should.not.containEql('files/index-import-1.css');
-			indexCss.should.not.containEql('files/index-import-2.css');
-			indexCss.should.not.containEql('http://example.com/files/index-image-1.png');
-			indexCss.should.containEql('index-import-1.css');
-			indexCss.should.containEql('index-import-2.css');
-			indexCss.should.containEql('../img/index-image-1.png');
+		await `${testDirname}/img/index-image-1.png`.should.fileExists(true);
+		await `${testDirname}/img/index-image-2.png`.should.fileExists(true);
 
-			const indexImportCss = fs.readFileSync(testDirname + '/css/index-import-2.css').toString();
-			indexImportCss.should.not.containEql('http://example.com/files/index-image-2.png');
-			indexImportCss.should.containEql('../img/index-image-2.png');
+		// all sources in index.css should be replaces with local files recursively
+		const indexCss = await fs.readFile(testDirname + '/css/index.css', { encoding: 'binary' });
+		indexCss.should.not.containEql('files/index-import-1.css');
+		indexCss.should.not.containEql('files/index-import-2.css');
+		indexCss.should.not.containEql('http://example.com/files/index-image-1.png');
+		indexCss.should.containEql('index-import-1.css');
+		indexCss.should.containEql('index-import-2.css');
+		indexCss.should.containEql('../img/index-image-1.png');
 
-			// should deal with base tag in about.html and not load new resources
-			// all sources in about.html should be replaced with already loaded local resources
-			$ = cheerio.load(fs.readFileSync(testDirname + '/about.html').toString());
-			$('link[rel="stylesheet"]').attr('href').should.be.eql('css/index.css');
-			$('style').html().should.containEql('img/background.png');
-			$('img').attr('src').should.be.eql('img/cat.jpg');
-			$('script').attr('src').should.be.eql('js/script.min.js');
+		const indexImportCss = await fs.readFile(testDirname + '/css/index-import-2.css', { encoding: 'binary' });
+		indexImportCss.should.not.containEql('http://example.com/files/index-image-2.png');
+		indexImportCss.should.containEql('../img/index-image-2.png');
 
-			// should not replace not loaded files
-			$ = cheerio.load(fs.readFileSync(testDirname + '/blog.html').toString());
-			$('img').attr('src').should.be.eql('files/fail-1.png');
-		});
+		// should deal with base tag in about.html and not load new resources
+		// all sources in about.html should be replaced with already loaded local resources
+		$ = cheerio.load(await fs.readFile(testDirname + '/about.html', { encoding: 'binary' }));
+		$('link[rel="stylesheet"]').attr('href').should.be.eql('css/index.css');
+		$('style').html().should.containEql('img/background.png');
+		$('img').attr('src').should.be.eql('img/cat.jpg');
+		$('script').attr('src').should.be.eql('js/script.min.js');
+
+		// should not replace not loaded files
+		$ = cheerio.load(await fs.readFile(testDirname + '/blog.html', { encoding: 'binary' }));
+		$('img').attr('src').should.be.eql('files/fail-1.png');
 	});
 
-	it('should load multiple urls to single directory with all specified sources with bySiteStructureFilenameGenerator', () => {
-		return scrape({...options, filenameGenerator: 'bySiteStructure'}).then(function(result) {
-			result.should.be.instanceOf(Array).and.have.length(3);
+	it('should load multiple urls to single directory with all specified sources with bySiteStructureFilenameGenerator', async () => {
+		const result = await scrape({...options, filenameGenerator: 'bySiteStructure'});
+		result.should.be.instanceOf(Array).and.have.length(3);
 
-			should(result[0].url).eql('http://example.com/');
-			should(result[0].filename).equalFileSystemPath('example.com/index.html');
-			result[0].should.have.properties('children');
-			result[0].children.should.be.instanceOf(Array).and.have.length(4);
-			result[0].children[0].should.be.instanceOf(Resource);
+		should(result[0].url).eql('http://example.com/');
+		should(result[0].filename).equalFileSystemPath('example.com/index.html');
+		result[0].should.have.properties('children');
+		result[0].children.should.be.instanceOf(Array).and.have.length(4);
+		result[0].children[0].should.be.instanceOf(Resource);
 
-			should(result[1].url).eql('http://example.com/about');
-			should(result[1].filename).equalFileSystemPath('example.com/about/index.html');
-			result[1].should.have.properties('children');
-			result[1].children.should.be.instanceOf(Array).and.have.length(4);
-			result[1].children[0].should.be.instanceOf(Resource);
+		should(result[1].url).eql('http://example.com/about');
+		should(result[1].filename).equalFileSystemPath('example.com/about/index.html');
+		result[1].should.have.properties('children');
+		result[1].children.should.be.instanceOf(Array).and.have.length(4);
+		result[1].children[0].should.be.instanceOf(Resource);
 
-			should(result[2].url).eql('http://blog.example.com/');  // url after redirect
-			should(result[2].filename).equalFileSystemPath('blog.example.com/index.html');
-			result[2].should.have.properties('children');
-			result[2].children.should.be.instanceOf(Array).and.have.length(1);
-			result[2].children[0].should.be.instanceOf(Resource);
+		should(result[2].url).eql('http://blog.example.com/');  // url after redirect
+		should(result[2].filename).equalFileSystemPath('blog.example.com/index.html');
+		result[2].should.have.properties('children');
+		result[2].children.should.be.instanceOf(Array).and.have.length(1);
+		result[2].children[0].should.be.instanceOf(Resource);
 
-			// should create directory and subdirectories
-			fs.existsSync(testDirname).should.be.eql(true);
-			fs.existsSync(testDirname + '/example.com/about').should.be.eql(true);
-			fs.existsSync(testDirname + '/example.com/files').should.be.eql(true);
-			fs.existsSync(testDirname + '/blog.example.com').should.be.eql(true);
+		// should create directory and subdirectories
+		await `${testDirname}`.should.dirExists(true);
+		await `${testDirname}/example.com/about`.should.dirExists(true);
+		await `${testDirname}/example.com/files`.should.dirExists(true);
+		await `${testDirname}/blog.example.com`.should.dirExists(true);
 
-			// should contain all sources found in index.html
-			fs.existsSync(testDirname + '/example.com/index.css').should.be.eql(true);
-			fs.existsSync(testDirname + '/example.com/background.png').should.be.eql(true);
-			fs.existsSync(testDirname + '/example.com/cat.jpg').should.be.eql(true);
-			fs.existsSync(testDirname + '/example.com/script.min.js').should.be.eql(true);
+		// should contain all sources found in index.html
+		await `${testDirname}/example.com/index.css`.should.fileExists(true);
+		await `${testDirname}/example.com/background.png`.should.fileExists(true);
+		await `${testDirname}/example.com/cat.jpg`.should.fileExists(true);
+		await `${testDirname}/example.com/script.min.js`.should.fileExists(true);
 
-			// all sources in index.html should be replaced with local paths
-			let $ = cheerio.load(fs.readFileSync(testDirname + '/example.com/index.html').toString());
-			$('link[rel="stylesheet"]').attr('href').should.be.eql('index.css');
-			$('style').html().should.containEql('background.png');
-			$('img').attr('src').should.be.eql('cat.jpg');
-			$('script').attr('src').should.be.eql('script.min.js');
+		// all sources in index.html should be replaced with local paths
+		let $ = cheerio.load(await fs.readFile(testDirname + '/example.com/index.html', { encoding: 'binary' }));
+		$('link[rel="stylesheet"]').attr('href').should.be.eql('index.css');
+		$('style').html().should.containEql('background.png');
+		$('img').attr('src').should.be.eql('cat.jpg');
+		$('script').attr('src').should.be.eql('script.min.js');
 
-			// should contain all sources found in index.css recursively
-			fs.existsSync(testDirname + '/example.com/files/index-import-1.css').should.be.eql(true);
-			fs.existsSync(testDirname + '/example.com/files/index-import-2.css').should.be.eql(true);
-			fs.existsSync(testDirname + '/example.com/files/index-import-3.css').should.be.eql(true);
-			fs.existsSync(testDirname + '/example.com/files/index-image-1.png').should.be.eql(true);
-			fs.existsSync(testDirname + '/example.com/files/index-image-2.png').should.be.eql(true);
+		// should contain all sources found in index.css recursively
+		await `${testDirname}/example.com/files/index-import-1.css`.should.fileExists(true);
+		await `${testDirname}/example.com/files/index-import-2.css`.should.fileExists(true);
+		await `${testDirname}/example.com/files/index-import-3.css`.should.fileExists(true);
+		await `${testDirname}/example.com/files/index-image-1.png`.should.fileExists(true);
+		await `${testDirname}/example.com/files/index-image-2.png`.should.fileExists(true);
 
-			// all sources in index.css should be replaces with local files recursively
-			const indexCss = fs.readFileSync(testDirname + '/example.com/index.css').toString();
-			indexCss.should.containEql('files/index-import-1.css');
-			indexCss.should.containEql('files/index-import-2.css');
-			indexCss.should.containEql('files/index-image-1.png');
+		// all sources in index.css should be replaces with local files recursively
+		const indexCss = await fs.readFile(testDirname + '/example.com/index.css', { encoding: 'binary' });
+		indexCss.should.containEql('files/index-import-1.css');
+		indexCss.should.containEql('files/index-import-2.css');
+		indexCss.should.containEql('files/index-image-1.png');
 
-			const indexImportCss = fs.readFileSync(testDirname + '/example.com/files/index-import-2.css').toString();
-			indexImportCss.should.containEql('index-image-2.png');
+		const indexImportCss = await fs.readFile(testDirname + '/example.com/files/index-import-2.css', { encoding: 'binary' });
+		indexImportCss.should.containEql('index-image-2.png');
 
-			// should deal with base tag in about.html and not load new resources
-			// all sources in about.html should be replaced with already loaded local resources
-			$ = cheerio.load(fs.readFileSync(testDirname + '/example.com/about/index.html').toString());
-			$('link[rel="stylesheet"]').attr('href').should.be.eql('../index.css');
-			$('style').html().should.containEql('../background.png');
-			$('img').attr('src').should.be.eql('../cat.jpg');
-			$('script').attr('src').should.be.eql('../script.min.js');
+		// should deal with base tag in about.html and not load new resources
+		// all sources in about.html should be replaced with already loaded local resources
+		$ = cheerio.load(await fs.readFile(testDirname + '/example.com/about/index.html', { encoding: 'binary' }));
+		$('link[rel="stylesheet"]').attr('href').should.be.eql('../index.css');
+		$('style').html().should.containEql('../background.png');
+		$('img').attr('src').should.be.eql('../cat.jpg');
+		$('script').attr('src').should.be.eql('../script.min.js');
 
-			// should not replace not loaded files
-			$ = cheerio.load(fs.readFileSync(testDirname + '/blog.example.com/index.html').toString());
-			$('img').attr('src').should.be.eql('files/fail-1.png');
-		});
+		// should not replace not loaded files
+		$ = cheerio.load(await fs.readFile(testDirname + '/blog.example.com/index.html', { encoding: 'binary' }));
+		$('img').attr('src').should.be.eql('files/fail-1.png');
 	});
 });

--- a/test/functional/base/check-it-works.js
+++ b/test/functional/base/check-it-works.js
@@ -1,22 +1,22 @@
 import should from 'should';
 import '../../utils/assertions.js';
 import nock from 'nock';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import scrape from 'website-scraper';
 
 const testDirname = './test/functional/base/.tmp2';
 
-describe('Functional: check it works', function() {
+describe('Functional: check it works', () => {
 
-	beforeEach(function () {
+	beforeEach(() => {
 		nock.cleanAll();
 		nock.disableNetConnect();
 	});
 
-	afterEach(function () {
+	afterEach(async () => {
 		nock.cleanAll();
 		nock.enableNetConnect();
-		fs.removeSync(testDirname);
+		await fs.rm(testDirname, { recursive: true, force: true });
 	});
 
 	it('should work with promise', () => {

--- a/test/functional/callbacks/callbacks.test.js
+++ b/test/functional/callbacks/callbacks.test.js
@@ -1,7 +1,7 @@
 import should from 'should';
 import '../../utils/assertions.js';
 import nock from 'nock';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import sinon from 'sinon';
 import scrape from 'website-scraper';
 
@@ -14,10 +14,10 @@ describe('Functional: onResourceSaved and onResourceError callbacks in plugin', 
 		nock.disableNetConnect();
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		nock.cleanAll();
 		nock.enableNetConnect();
-		fs.removeSync(testDirname);
+		await fs.rm(testDirname, { recursive: true, force: true });
 	});
 
 	it('should call onResourceSaved callback and onResourceError callback if ignoreErrors = true', function() {

--- a/test/functional/data-url/data-url.test.js
+++ b/test/functional/data-url/data-url.test.js
@@ -1,26 +1,26 @@
 import should from 'should';
 import '../../utils/assertions.js';
 import nock from 'nock';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import scrape from 'website-scraper';
 
 const testDirname = './test/functional/data-url/.tmp';
 const mockDirname = './test/functional/data-url/mocks';
 
-describe('Functional: data urls handling', function () {
+describe('Functional: data urls handling', () => {
 
-	beforeEach(function () {
+	beforeEach(() => {
 		nock.cleanAll();
 		nock.disableNetConnect();
 	});
 
-	afterEach(function () {
+	afterEach(async () => {
 		nock.cleanAll();
 		nock.enableNetConnect();
-		fs.removeSync(testDirname);
+		await fs.rm(testDirname, { recursive: true, force: true });
 	});
 
-	it('should correctly handle html files with data urls in attributes', function () {
+	it('should correctly handle html files with data urls in attributes', async () => {
 		nock('http://example.com/').get('/').replyWithFile(200, mockDirname + '/index.html');
 		nock('http://example.com/').get('/product/abc/media/521811121-392x351.jpg').reply(200, '/product/abc/media/521811121-392x351.jpg');
 		const options = {
@@ -31,18 +31,16 @@ describe('Functional: data urls handling', function () {
 			}
 		};
 
-		return scrape(options).then(function () {
-			fs.existsSync(testDirname + '/index.html').should.be.eql(true);
-			fs.existsSync(testDirname + '/images/521811121-392x351.jpg').should.be.eql(true);
+		await scrape(options);
+		await `${testDirname}/index.html`.should.fileExists(true);
+		await `${testDirname}/images/521811121-392x351.jpg`.should.fileExists(true);
 
-			const actualIndexHtml = fs.readFileSync(testDirname + '/index.html').toString();
-
-			should(actualIndexHtml).containEql('<source media="(max-width: 559px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
-			should(actualIndexHtml).containEql('<source media="(min-width: 560px) and (max-width: 719px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
-			should(actualIndexHtml).containEql('<source media="(min-width: 720px) and (max-width: 899px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
-			should(actualIndexHtml).containEql('<source media="(min-width: 900px) and (max-width: 1199px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
-			should(actualIndexHtml).containEql('<source media="(min-width: 1200px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
-			should(actualIndexHtml).containEql('<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" srcset="images/521811121-392x351.jpg 2x">');
-		});
+		const actualIndexHtml = await fs.readFile(testDirname + '/index.html', { encoding: 'binary' });
+		should(actualIndexHtml).containEql('<source media="(max-width: 559px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
+		should(actualIndexHtml).containEql('<source media="(min-width: 560px) and (max-width: 719px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
+		should(actualIndexHtml).containEql('<source media="(min-width: 720px) and (max-width: 899px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
+		should(actualIndexHtml).containEql('<source media="(min-width: 900px) and (max-width: 1199px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
+		should(actualIndexHtml).containEql('<source media="(min-width: 1200px)" srcset="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 1x, data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7 2x">');
+		should(actualIndexHtml).containEql('<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" srcset="images/521811121-392x351.jpg 2x">');
 	});
 });

--- a/test/functional/encoding/hieroglyphs.test.js
+++ b/test/functional/encoding/hieroglyphs.test.js
@@ -6,8 +6,7 @@ import scrape from 'website-scraper';
 const testDirname = './test/functional/encoding/.tmp';
 const mockDirname = './test/functional/encoding/mocks';
 
-// TODO: enable test when encoding issue is fixed
-xdescribe('Functional: Korean characters are properly encoded/decoded', () => {
+describe('Functional: Korean characters are properly encoded/decoded', () => {
 	const options = {
 		urls: [
 			'http://example.com/',

--- a/test/functional/encoding/hieroglyphs.test.js
+++ b/test/functional/encoding/hieroglyphs.test.js
@@ -1,13 +1,13 @@
 import '../../utils/assertions.js';
 import nock from 'nock';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import scrape from 'website-scraper';
 
 const testDirname = './test/functional/encoding/.tmp';
 const mockDirname = './test/functional/encoding/mocks';
 
 // TODO: enable test when encoding issue is fixed
-xdescribe('Functional: Korean characters are properly encoded/decoded', function() {
+xdescribe('Functional: Korean characters are properly encoded/decoded', () => {
 	const options = {
 		urls: [
 			'http://example.com/',
@@ -16,27 +16,27 @@ xdescribe('Functional: Korean characters are properly encoded/decoded', function
 		ignoreErrors: false
 	};
 
-	beforeEach(function() {
+	beforeEach(() => {
 		nock.cleanAll();
 		nock.disableNetConnect();
 	});
 
-	afterEach(function() {
+	afterEach(async () => {
 		nock.cleanAll();
 		nock.enableNetConnect();
-		fs.removeSync(testDirname);
+		await fs.rm(testDirname, { recursive: true, force: true });
 	});
 
 	beforeEach(() => {
-		nock('http://example.com/').get('/').replyWithFile(200, mockDirname + '/index.html', {'content-type': 'text/html'});
+		nock('http://example.com/').get('/').replyWithFile(200, mockDirname + '/index.html', {'content-type': 'text/html; charset=utf-8'});
 	});
 
-	it('should save the page in the same data as it was originally', () => {
-		return scrape(options).then(function(result) {
-			const scrapedIndex = fs.readFileSync(testDirname + '/index.html').toString();
-			scrapedIndex.should.be.containEql('<div id="special-characters-korean">저는 7년 동안 한국에서 살았어요.</div>');
-			scrapedIndex.should.be.containEql('<div id="special-characters-ukrainian">Слава Україні!</div>');
-			scrapedIndex.should.be.containEql('<div id="special-characters-chinese">加入网站</div>');
-		});
+	it('should save the page in the same data as it was originally', async () => {
+		await scrape(options);
+
+		const scrapedIndex = await fs.readFile(testDirname + '/index.html', { encoding: 'utf8' });
+		scrapedIndex.should.be.containEql('<div id="special-characters-korean">저는 7년 동안 한국에서 살았어요.</div>');
+		scrapedIndex.should.be.containEql('<div id="special-characters-ukrainian">Слава Україні!</div>');
+		scrapedIndex.should.be.containEql('<div id="special-characters-chinese">加入网站</div>');
 	});
 });

--- a/test/functional/html-id-href/html-id-href.test.js
+++ b/test/functional/html-id-href/html-id-href.test.js
@@ -1,26 +1,26 @@
 import should from 'should';
 import '../../utils/assertions.js';
 import nock from 'nock';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import scrape from 'website-scraper';
 
 const testDirname = './test/functional/html-id-href/.tmp';
 const mockDirname = './test/functional/html-id-href/mocks';
 
-describe('Functional html id href', function() {
+describe('Functional html id href', () => {
 
-	beforeEach(function() {
+	beforeEach(() => {
 		nock.cleanAll();
 		nock.disableNetConnect();
 	});
 
-	afterEach(function() {
+	afterEach(async () => {
 		nock.cleanAll();
 		nock.enableNetConnect();
-		fs.removeSync(testDirname);
+		await fs.rm(testDirname, { recursive: true, force: true });
 	});
 
-	it('should ignore same-file paths and update other-file paths', function() {
+	it('should ignore same-file paths and update other-file paths', async () => {
 		nock('http://example.com/').get('/').replyWithFile(200, mockDirname + '/index.html');
 		nock('http://example.com/').get('/sprite.svg').reply(200, 'sprite.svg');
 		nock('https://mdn.mozillademos.org/').get('/files/6457/mdn_logo_only_color.png').reply(200, 'mdn_logo_only_color.png');
@@ -41,24 +41,23 @@ describe('Functional html id href', function() {
 			]
 		};
 
-		return scrape(options).then(function() {
-			fs.existsSync(testDirname + '/index.html').should.be.eql(true);
-			fs.existsSync(testDirname + '/other.html').should.be.eql(true);
-			fs.existsSync(testDirname + '/local/sprite.svg').should.be.eql(true);
-			fs.existsSync(testDirname + '/local/mdn_logo_only_color.png').should.be.eql(true);
+		await scrape(options);
+		`${testDirname}/index.html`.should.fileExists(true);
+		`${testDirname}/other.html`.should.fileExists(true);
+		`${testDirname}/local/sprite.svg`.should.fileExists(true);
+		`${testDirname}/local/mdn_logo_only_color.png`.should.fileExists(true);
 
-			const indexHtml = fs.readFileSync(testDirname + '/index.html').toString();
+		const indexHtml = await fs.readFile(testDirname + '/index.html', { encoding: 'binary' });
 
-			// should update path to external svgs
-			should(indexHtml).containEql('xlink:href="local/sprite.svg#icon-undo"');
-			should(indexHtml).containEql('href="local/sprite.svg#icon-redo"');
-			// should keep links to local svgs
-			should(indexHtml).containEql('xlink:href="#codrops" class="codrops-1"');
-			should(indexHtml).containEql('xlink:href="#codrops" class="codrops-2"');
-			should(indexHtml).containEql('xlink:href="#codrops" class="codrops-3"');
+		// should update path to external svgs
+		should(indexHtml).containEql('xlink:href="local/sprite.svg#icon-undo"');
+		should(indexHtml).containEql('href="local/sprite.svg#icon-redo"');
+		// should keep links to local svgs
+		should(indexHtml).containEql('xlink:href="#codrops" class="codrops-1"');
+		should(indexHtml).containEql('xlink:href="#codrops" class="codrops-2"');
+		should(indexHtml).containEql('xlink:href="#codrops" class="codrops-3"');
 
-			should(indexHtml).containEql('<a href="#top">Go to top (this page)</a>');
-			should(indexHtml).containEql('<a href="other.html#top">Go to top (other page)</a>');
-		});
+		should(indexHtml).containEql('<a href="#top">Go to top (this page)</a>');
+		should(indexHtml).containEql('<a href="other.html#top">Go to top (other page)</a>');
 	});
 });

--- a/test/functional/request-concurrency/request-concurrency.test.js
+++ b/test/functional/request-concurrency/request-concurrency.test.js
@@ -1,16 +1,16 @@
 import 'should';
 import '../../utils/assertions.js';
 import nock from 'nock';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import scrape from 'website-scraper';
 
 const testDirname = './test/functional/request-concurrency/.tmp';
 const mockDirname = './test/functional/request-concurrency/mocks';
 
-describe('Functional concurrent requests', function() {
+describe('Functional concurrent requests', () => {
 	let maxConcurrentRequests, currentConcurrentRequests;
 
-	beforeEach(function () {
+	beforeEach(() => {
 		nock.cleanAll();
 		nock.disableNetConnect();
 
@@ -54,10 +54,10 @@ describe('Functional concurrent requests', function() {
 		return scrape(options);
 	});
 
-	afterEach(function () {
+	afterEach(async () => {
 		nock.cleanAll();
 		nock.enableNetConnect();
-		fs.removeSync(testDirname);
+		await fs.rm(testDirname, { recursive: true, force: true });
 	});
 
 	it('should have maximum concurrent requests == requestConcurrency option', () => {

--- a/test/functional/request-response-customizations/request.test.js
+++ b/test/functional/request-response-customizations/request.test.js
@@ -1,26 +1,26 @@
 import should from 'should';
 import '../../utils/assertions.js';
 import nock from 'nock';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import scrape from 'website-scraper';
 
 const testDirname = './test/functional/req-res-customizations-request/.tmp';
 const mockDirname = './test/functional/req-res-customizations-request/mocks';
 
-describe('Functional: customize request options with plugin', function() {
+describe('Functional: customize request options with plugin', () => {
 
-	beforeEach(function() {
+	beforeEach(() => {
 		nock.cleanAll();
 		nock.disableNetConnect();
 	});
 
-	afterEach(function() {
+	afterEach(async () => {
 		nock.cleanAll();
 		nock.enableNetConnect();
-		fs.removeSync(testDirname);
+		await fs.rm(testDirname, { recursive: true, force: true });
 	});
 
-	it('should use options from request property if no beforeRequest actions', function() {
+	it('should use options from request property if no beforeRequest actions', async () => {
 		nock('http://example.com/').get('/').query({myParam: 122}).reply(200, 'response for url with query');
 
 		const options = {
@@ -31,18 +31,18 @@ describe('Functional: customize request options with plugin', function() {
 			}
 		};
 
-		return scrape(options).then(function() {
-			fs.existsSync(testDirname + '/index.html').should.be.eql(true);
-			const indexHtml = fs.readFileSync(testDirname + '/index.html').toString();
-			should(indexHtml).containEql('response for url with query');
-		});
+		await scrape(options);
+
+		(await fs.stat(testDirname + '/index.html')).isFile().should.be.eql(true);
+		const indexHtml = await fs.readFile(testDirname + '/index.html', { encoding: 'binary'});
+		should(indexHtml).containEql('response for url with query');
 	});
 
-	it('should use options returned by beforeRequest action', function() {
+	it('should use options returned by beforeRequest action', async () => {
 		nock('http://example.com/').get('/').query({myParam: 122}).reply(200, 'response for url with query');
 
 		class CustomRequestOptions {
-			apply(add) {
+			apply (add) {
 				add('beforeRequest', ()=> {
 					return {
 						requestOptions:{
@@ -61,10 +61,10 @@ describe('Functional: customize request options with plugin', function() {
 			]
 		};
 
-		return scrape(options).then(function() {
-			fs.existsSync(testDirname + '/index.html').should.be.eql(true);
-			const indexHtml = fs.readFileSync(testDirname + '/index.html').toString();
-			should(indexHtml).containEql('response for url with query');
-		});
+		await scrape(options);
+
+		(await fs.stat(testDirname + '/index.html')).isFile().should.be.eql(true);
+		const indexHtml = await fs.readFile(testDirname + '/index.html', { encoding: 'binary' });
+		indexHtml.should.containEql('response for url with query');
 	});
 });

--- a/test/functional/resource-without-ext/resource-without-ext.test.js
+++ b/test/functional/resource-without-ext/resource-without-ext.test.js
@@ -1,26 +1,26 @@
 import 'should';
 import '../../utils/assertions.js';
 import nock from 'nock';
-import fs from 'fs-extra';
+import fs from 'fs/promises';
 import scrape from 'website-scraper';
 
 const testDirname = './test/functional/resource-without-ext/.tmp';
 const mockDirname = './test/functional/resource-without-ext/mocks';
 
-describe('Functional resources without extensions', function() {
+describe('Functional resources without extensions', () => {
 
-	beforeEach(function() {
+	beforeEach(() => {
 		nock.cleanAll();
 		nock.disableNetConnect();
 	});
 
-	afterEach(function() {
+	afterEach(async () => {
 		nock.cleanAll();
 		nock.enableNetConnect();
-		fs.removeSync(testDirname);
+		await fs.rm(testDirname, { recursive: true, force: true });
 	});
 
-	it('should load resources without extensions with correct type and wrap with extensions', function () {
+	it('should load resources without extensions with correct type and wrap with extensions', async () => {
 		const options = {
 			urls: [ 'http://example.com/' ],
 			directory: testDirname,
@@ -52,19 +52,19 @@ describe('Functional resources without extensions', function() {
 		nock('http://google.com').get('/').replyWithFile(200, mockDirname + '/google.html');
 		nock('http://google.com').get('/google.png').reply(200, 'OK');
 
-		return scrape(options).then(function() {
-			// should load css file and fonts from css file
-			fs.existsSync(testDirname + '/css.css').should.be.eql(true); // http://fonts.googleapis.com/css?family=Lato
-			fs.existsSync(testDirname + '/UyBMtLsHKBKXelqf4x7VRQ.woff2').should.be.eql(true);
-			fs.existsSync(testDirname + '/1YwB1sO8YE1Lyjf12WNiUA.woff2').should.be.eql(true);
+		await scrape(options);
 
-			// should load html file and its sources from anchor
-			fs.existsSync(testDirname + '/index_1.html').should.be.eql(true);
-			fs.existsSync(testDirname + '/google.png').should.be.eql(true);
+		// should load css file and fonts from css file
+		(await fs.stat(testDirname + '/css.css')).isFile().should.be.eql(true); // http://fonts.googleapis.com/css?family=Lato
+		(await fs.stat(testDirname + '/UyBMtLsHKBKXelqf4x7VRQ.woff2')).isFile().should.be.eql(true);
+		(await fs.stat(testDirname + '/1YwB1sO8YE1Lyjf12WNiUA.woff2')).isFile().should.be.eql(true);
 
-			// should load html file and its sources from iframe
-			fs.existsSync(testDirname + '/iframe.html').should.be.eql(true);
-			fs.existsSync(testDirname + '/cat.png').should.be.eql(true);
-		});
+		// should load html file and its sources from anchor
+		(await fs.stat(testDirname + '/index_1.html')).isFile().should.be.eql(true);
+		(await fs.stat(testDirname + '/google.png')).isFile().should.be.eql(true);
+
+		// should load html file and its sources from iframe
+		(await fs.stat(testDirname + '/iframe.html')).isFile().should.be.eql(true);
+		(await fs.stat(testDirname + '/cat.png')).isFile().should.be.eql(true);
 	});
 });

--- a/test/unit/request-test.js
+++ b/test/unit/request-test.js
@@ -66,12 +66,14 @@ describe('request', () => {
 			nock(url).get('/').reply(200, 'TEST BODY');
 			const handlerStub = sinon.stub().resolves({
 				body: 'a',
-				metadata: 'b'
+				metadata: 'b',
+				encoding: 'utf8'
 			});
 
 			return request.get({url, afterResponse: handlerStub}).then((data) => {
 				should(data.body).be.eql('a');
 				should(data.metadata).be.eql('b');
+				should(data.encoding).be.eql('utf8');
 			});
 		});
 
@@ -85,6 +87,7 @@ describe('request', () => {
 			return request.get({url, afterResponse: handlerStub}).then((data) => {
 				should(data.body).be.eql('a');
 				should(data.metadata).be.eql(null);
+				should(data.encoding).be.eql('binary');
 			});
 		});
 
@@ -124,6 +127,7 @@ describe('request', () => {
 			data.url.should.be.eql('http://www.google.com/');
 			data.body.should.be.eql('Hello from Google!');
 			data.mimeType.should.be.eql('text/html');
+			data.encoding.should.be.eql('utf8');
 		});
 	});
 
@@ -135,6 +139,7 @@ describe('request', () => {
 			data.should.have.properties(['url', 'body', 'mimeType']);
 			data.url.should.be.eql('http://www.google.com/');
 			data.body.should.be.eql('Hello from Google!');
+			data.encoding.should.be.eql('binary');
 			should(data.mimeType).be.eql(null);
 		});
 	});

--- a/test/unit/resource-handler/css.test.js
+++ b/test/unit/resource-handler/css.test.js
@@ -4,15 +4,15 @@ import Resource from '../../../lib/resource.js';
 import CssResourceHandler from '../../../lib/resource-handler/css/index.js';
 
 describe('ResourceHandler: Css', () => {
-	it('should call downloadChildrenResources and set returned text to resource', () => {
+	it('should call downloadChildrenResources and set returned text to resource', async () => {
 		const downloadChildrenPaths = sinon.stub().resolves('updated text');
 
 		const originalResource = new Resource('http://example.com');
 		const cssHandler = new CssResourceHandler({}, {downloadChildrenPaths});
 
-		return cssHandler.handle(originalResource).then((updatedResource) => {
-			should(updatedResource).be.equal(originalResource);
-			should(updatedResource.getText()).be.eql('updated text');
-		});
+		const updatedResource = await cssHandler.handle(originalResource);
+
+		should(updatedResource).be.equal(originalResource);
+		should(await updatedResource.getText()).be.eql('updated text');
 	});
 });

--- a/test/unit/resource-handler/html.test.js
+++ b/test/unit/resource-handler/html.test.js
@@ -70,7 +70,7 @@ describe('ResourceHandler: Html', () => {
 			htmlHandler = new HtmlHandler({ sources: [] }, {downloadChildrenPaths});
 		});
 
-		it('should remove base tag from text and update resource url for absolute href', () => {
+		it('should remove base tag from text and update resource url for absolute href', async () => {
 			const html = `
 				<html lang="en">
 				<head>
@@ -80,15 +80,14 @@ describe('ResourceHandler: Html', () => {
 				</html>
 			`;
 			const resource = new Resource('http://example.com', 'index.html');
-			resource.setText(html);
+			await resource.setText(html);
 
-			return htmlHandler.handle(resource).then(() =>{
-				resource.getUrl().should.be.eql('http://some-other-domain.com/src');
-				resource.getText().should.not.containEql('<base');
-			});
+			const handledResource = await htmlHandler.handle(resource);
+			handledResource.getUrl().should.be.eql('http://some-other-domain.com/src');
+			(await handledResource.getText()).should.not.containEql('<base');
 		});
 
-		it('should remove base tag from text and update resource url for relative href', () => {
+		it('should remove base tag from text and update resource url for relative href', async () => {
 			const html = `
 				<html lang="en">
 				<head>
@@ -98,15 +97,14 @@ describe('ResourceHandler: Html', () => {
 				</html>
 			`;
 			const resource = new Resource('http://example.com', 'index.html');
-			resource.setText(html);
+			await resource.setText(html);
 
-			return htmlHandler.handle(resource).then(() => {
-				resource.getUrl().should.be.eql('http://example.com/src');
-				resource.getText().should.not.containEql('<base');
-			});
+			const handledResource = await htmlHandler.handle(resource);
+			handledResource.getUrl().should.be.eql('http://example.com/src');
+			(await handledResource.getText()).should.not.containEql('<base');
 		});
 
-		it('should not remove base tag if it doesn\'t have href attribute', () => {
+		it('should not remove base tag if it doesn\'t have href attribute', async () => {
 			const html = `
 				<html lang="en">
 				<head>
@@ -116,16 +114,15 @@ describe('ResourceHandler: Html', () => {
 				</html>
 			`;
 			const resource = new Resource('http://example.com', 'index.html');
-			resource.setText(html);
+			await resource.setText(html);
 
-			return htmlHandler.handle(resource).then(() => {
-				resource.getUrl().should.be.eql('http://example.com');
-				resource.getText().should.containEql('<base target="_blank">');
-			});
+			const handledResource = await htmlHandler.handle(resource);
+			handledResource.getUrl().should.be.eql('http://example.com');
+			(await handledResource.getText()).should.containEql('<base target="_blank">');
 		});
 	});
 
-	it('should not encode text to html entities', () => {
+	it('should not encode text to html entities', async () => {
 		htmlHandler = new HtmlHandler({ sources: [] }, {downloadChildrenPaths});
 		const html = `
 			<html>
@@ -136,14 +133,13 @@ describe('ResourceHandler: Html', () => {
 		`;
 
 		const resource = new Resource('http://example.com', 'index.html');
-		resource.setText(html);
+		await resource.setText(html);
 
-		return htmlHandler.handle(resource).then(() => {
-			resource.getText().should.containEql('Этот текст не должен быть преобразован в html entities');
-		});
+		const handledResource = await htmlHandler.handle(resource);
+		(await handledResource.getText()).should.containEql('Этот текст не должен быть преобразован в html entities');
 	});
 
-	it('should not update attribute names to lowercase', () => {
+	it('should not update attribute names to lowercase', async () => {
 		htmlHandler = new HtmlHandler({ sources: [] }, {downloadChildrenPaths});
 		const html = `
 			<html>
@@ -156,14 +152,13 @@ describe('ResourceHandler: Html', () => {
 		`;
 
 		const resource = new Resource('http://example.com', 'index.html');
-		resource.setText(html);
+		await resource.setText(html);
 
-		return htmlHandler.handle(resource).then(() => {
-			resource.getText().should.containEql('viewBox="0 0 100 100"');
-		});
+		const handledResource = await htmlHandler.handle(resource);
+		(await handledResource.getText()).should.containEql('viewBox="0 0 100 100"');
 	});
 
-	it('should call downloadChildrenResources for each source', () => {
+	it('should call downloadChildrenResources for each source', async () => {
 		const sources = [{ selector: 'img', attr: 'src' }];
 		htmlHandler = new HtmlHandler({sources}, {downloadChildrenPaths});
 
@@ -179,14 +174,13 @@ describe('ResourceHandler: Html', () => {
 		`;
 
 		const resource = new Resource('http://example.com', 'index.html');
-		resource.setText(html);
+		await resource.setText(html);
 
-		return htmlHandler.handle(resource).then(() =>{
-			htmlHandler.downloadChildrenPaths.calledThrice.should.be.eql(true);
-		});
+		await htmlHandler.handle(resource);
+		htmlHandler.downloadChildrenPaths.calledThrice.should.be.eql(true);
 	});
 
-	it('should not call downloadChildrenResources if source attr is empty', () =>{
+	it('should not call downloadChildrenResources if source attr is empty', async () =>{
 		const sources = [{ selector: 'img', attr: 'src' }];
 		htmlHandler = new HtmlHandler({sources}, {downloadChildrenPaths});
 
@@ -198,14 +192,13 @@ describe('ResourceHandler: Html', () => {
 		`;
 
 		const resource = new Resource('http://example.com', 'index.html');
-		resource.setText(html);
+		await resource.setText(html);
 
-		return htmlHandler.handle(resource).then(() =>{
-			htmlHandler.downloadChildrenPaths.called.should.be.eql(false);
-		});
+		await htmlHandler.handle(resource)
+		htmlHandler.downloadChildrenPaths.called.should.be.eql(false);
 	});
 
-	it('should use correct path containers based on tag', () => {
+	it('should use correct path containers based on tag', async () => {
 		const sources = [
 			{ selector: 'img', attr: 'src' },
 			{ selector: 'img', attr: 'srcset' },
@@ -225,17 +218,16 @@ describe('ResourceHandler: Html', () => {
 		`;
 
 		const resource = new Resource('http://example.com', 'index.html');
-		resource.setText(html);
+		await resource.setText(html);
 
-		return htmlHandler.handle(resource).then(() =>{
-			htmlHandler.downloadChildrenPaths.calledThrice.should.be.eql(true);
-			htmlHandler.downloadChildrenPaths.args[0][0].should.be.instanceOf(HtmlCommonTag);
-			htmlHandler.downloadChildrenPaths.args[1][0].should.be.instanceOf(HtmlImgSrcsetTag);
-			htmlHandler.downloadChildrenPaths.args[2][0].should.be.instanceOf(CssText);
-		});
+		await htmlHandler.handle(resource);
+		htmlHandler.downloadChildrenPaths.calledThrice.should.be.eql(true);
+		htmlHandler.downloadChildrenPaths.args[0][0].should.be.instanceOf(HtmlCommonTag);
+		htmlHandler.downloadChildrenPaths.args[1][0].should.be.instanceOf(HtmlImgSrcsetTag);
+		htmlHandler.downloadChildrenPaths.args[2][0].should.be.instanceOf(CssText);
 	});
 
-	it('should remove SRI check for loaded resources', () => {
+	it('should remove SRI check for loaded resources', async () => {
 		const sources = [
 			{ selector: 'script', attr: 'src'}
 		];
@@ -253,18 +245,19 @@ describe('ResourceHandler: Html', () => {
 		`;
 
 		const resource = new Resource('http://example.com', 'index.html');
-		resource.setText(html);
+		await resource.setText(html);
 
 		// before handle should contain both integrity checks
-		resource.getText().should.containEql('integrity="sha256-gaWb8m2IHSkoZnT23u/necREOC//MiCFtQukVUYMyuU="');
-		resource.getText().should.containEql('integrity="sha256-X+Q/xqnlEgxCczSjjpp2AUGGgqM5gcBzhRQ0p+EAUEk="');
+		(await resource.getText()).should.containEql('integrity="sha256-gaWb8m2IHSkoZnT23u/necREOC//MiCFtQukVUYMyuU="');
+		(await resource.getText()).should.containEql('integrity="sha256-X+Q/xqnlEgxCczSjjpp2AUGGgqM5gcBzhRQ0p+EAUEk="');
 
-		return htmlHandler.handle(resource).then(() => {
-			// after handle should contain integrity check for styles
-			// but not contain integrity check for script because it was loaded
-			resource.getText().should.containEql('integrity="sha256-gaWb8m2IHSkoZnT23u/necREOC//MiCFtQukVUYMyuU="');
-			resource.getText().should.not.containEql('integrity="sha256-X+Q/xqnlEgxCczSjjpp2AUGGgqM5gcBzhRQ0p+EAUEk="');
-		});
+
+
+		const handledResource = await htmlHandler.handle(resource);
+		// after handle should contain integrity check for styles
+		// but not contain integrity check for script because it was loaded
+		(await handledResource.getText()).should.containEql('integrity="sha256-gaWb8m2IHSkoZnT23u/necREOC//MiCFtQukVUYMyuU="');
+		(await handledResource.getText()).should.not.containEql('integrity="sha256-X+Q/xqnlEgxCczSjjpp2AUGGgqM5gcBzhRQ0p+EAUEk="');
 	});
 
 	it('should use html entities for updated attributes', async () => {
@@ -283,10 +276,10 @@ describe('ResourceHandler: Html', () => {
 		`;
 
 		const resource = new Resource('http://example.com', 'index.html');
-		resource.setText(html);
+		await resource.setText(html);
 
-		await htmlHandler.handle(resource);
-		const text = resource.getText();
+		const handledResource = await htmlHandler.handle(resource);
+		const text = await handledResource.getText();
 
 		should(text).containEql('style="width: 300px; height: 300px; background-image:url(&quot;./images/cat.jpg&quot;)"');
 	});

--- a/test/unit/resource-test.js
+++ b/test/unit/resource-test.js
@@ -1,34 +1,84 @@
 import 'should';
 import Resource from '../../lib/resource.js';
+import fs from 'fs/promises';
+import '../utils/assertions.js';
 
-describe('Resource', function() {
-	describe('#createChild', function () {
-		it('should return Resource', function() {
+describe('Resource', () => {
+	describe('#createChild',  () => {
+		it('should return Resource', () => {
 			const parent = new Resource('http://example.com');
 			const child = parent.createChild('http://google.com');
 			child.should.be.instanceOf(Resource);
 		});
 
-		it('should set correct url and filename', function() {
+		it('should set correct url and filename', () => {
 			const parent = new Resource('http://example.com');
 			const child = parent.createChild('http://google.com', 'google.html');
 			child.getUrl().should.be.eql('http://google.com');
 			child.getFilename().should.equalFileSystemPath('google.html');
 		});
 
-		it('should set parent', function() {
+		it('should set parent', () => {
 			const parent = new Resource('http://example.com');
 			const child = parent.createChild('http://google.com');
 			child.parent.should.be.equal(parent);
 		});
 
-		it('should set depth', function() {
+		it('should set depth', () => {
 			const parent = new Resource('http://example.com');
 			const child = parent.createChild('http://google.com');
 			child.depth.should.be.eql(1);
 
 			const childOfChild = child.createChild('http://google.com.ua');
 			childOfChild.depth.should.be.eql(2);
+		});
+	});
+
+	describe('set/get text', () => {
+		const testString1 = '동안 한국에서';
+		const testString2 = '加入网站';
+
+		it('memory mode', async () => {
+			const resource = new Resource('http://example.com', 'index.html', 'memory');
+			resource.setEncoding('utf8');
+
+			await resource.setText(testString1);
+			(await resource.getText()).should.eql(testString1);
+
+			await resource.setText(testString2);
+			(await resource.getText()).should.eql(testString2);
+		});
+
+		it('memory-compressed mode', async () => {
+			const resource = new Resource('http://example.com', 'index.html', 'memory-compressed');
+			resource.setEncoding('utf8');
+
+			await resource.setText(testString1);
+			(await resource.getText()).should.eql(testString1);
+			(await resource._memoryRead()).should.not.eql(testString1);
+
+			await resource.setText(testString2);
+			(await resource.getText()).should.eql(testString2);
+		});
+
+		it('fs mode', async () => {
+			const resource = new Resource('http://example.com', 'index.html', 'fs');
+			resource.setEncoding('utf8');
+
+			resource.tmpDir.should.not.eql(undefined);
+
+			try {
+				const resource = new Resource('http://example.com', 'index.html', 'fs');
+				resource.setEncoding('utf8');
+
+				await resource.setText(testString1);
+				(await resource.getText()).should.eql(testString1);
+
+				await resource.setText(testString2);
+				(await resource.getText()).should.eql(testString2);
+			} finally {
+				await fs.rm(resource.tmpDir, { recursive: true, force: true });
+			}
 		});
 	});
 });

--- a/test/unit/scraper-init-test.js
+++ b/test/unit/scraper-init-test.js
@@ -121,7 +121,7 @@ describe('Scraper initialization', function () {
 
 			s.options.request.should.containEql({
 				throwHttpErrors: false,
-				encoding: 'binary',
+				responseType: 'buffer',
 				decompress: true,
 				https: {
 					rejectUnauthorized: false
@@ -143,7 +143,7 @@ describe('Scraper initialization', function () {
 
 			s.options.request.should.eql({
 				throwHttpErrors: true,
-				encoding: 'binary',
+				responseType: 'buffer',
 				decompress: true,
 				https: {
 					rejectUnauthorized: false

--- a/test/unit/scraper-test.js
+++ b/test/unit/scraper-test.js
@@ -251,7 +251,7 @@ describe('Scraper', () => {
 
 			class AddMetadataPlugin {
 				apply (registerAction) {
-					registerAction('afterResponse', sinon.stub().returns({body: 'test body', metadata}));
+					registerAction('afterResponse', sinon.stub().returns({body: 'test body', metadata, encoding: 'utf8'}));
 				}
 			}
 
@@ -272,6 +272,7 @@ describe('Scraper', () => {
 			should(r.getUrl()).be.eql('http://example.com');
 			should(r.getType()).be.eql('html');
 			should(r.getFilename()).be.eql('generated-filename');
+			should(r.getEncoding()).be.eql('utf8');
 			should(r.metadata).be.eql(metadata);
 		});
 	});

--- a/test/utils/assertions.js
+++ b/test/utils/assertions.js
@@ -1,11 +1,45 @@
 import _ from 'lodash';
 import path from 'path';
 import should from 'should';
-should.Assertion.add('equalFileSystemPath', function (value, description) {
+import fs from 'fs/promises';
+
+should.Assertion.add('equalFileSystemPath', function(value, description) {
 	value = path.normalize(value);
-	if (process.platform == 'win32' && _.startsWith(value, path.sep)) {
+	if (process.platform === 'win32' && _.startsWith(value, path.sep)) {
 		value = __dirname.split(path.sep)[0] + value;
 	}
 	this.params = { operator: 'to be', expected: value, message: description};
 	this.obj.should.equal(value, description);
+});
+
+should.Assertion.add('fileExists', async function(value, description) {
+	let exists = false;
+
+	try {
+		exists = (await fs.stat(this.obj)).isFile();
+	} catch (err) {
+		// We don't care about this error.
+	}
+
+	if (value === undefined) {
+		value = true;
+	}
+
+	exists.should.eql(value, description);
+});
+
+should.Assertion.add('dirExists', async function(value, description) {
+	let exists = false;
+
+	try {
+		exists = (await fs.stat(this.obj)).isDirectory();
+	} catch (err) {
+		// We don't care about this error.
+	}
+
+	if (value === undefined) {
+		value = true;
+	}
+
+	exists.should.eql(value, description);
 });


### PR DESCRIPTION
This closes #386 and is an extension of #496. This provides new options to store data in memory, in memory and compressed or on the filesystem. Unlikely #496 this would definitely require a major release as it makes significant changes to resource handling.

This PR also restructures a lot of tests and removes `fs-extra` as it's mostly not needed but also in our larger internal project we found it introduces a lot of compatibility issues for example with `memfs` which would be the best way of testing filesystem based tests, but this PR was big enough already. 