### PR TITLE
RFC: Refactor builtin plugins to expose class properties

### DIFF
--- a/lib/plugins/generate-filenamy-by-site-structure-plugin.js
+++ b/lib/plugins/generate-filenamy-by-site-structure-plugin.js
@@ -2,15 +2,17 @@ import bySiteStructureFilenameGenerator from '../filename-generator/by-site-stru
 
 class GenerateFilenameBySiteStructurePlugin {
 	apply (registerAction) {
-		let defaultFilename;
+		registerAction('beforeStart', this.beforeStart.bind(this))
+		registerAction('generateFilename', this.generateFilename.bind(this))
+	}
 
-		registerAction('beforeStart', ({options}) => {
-			defaultFilename = options.defaultFilename;
-		});
-		registerAction('generateFilename', ({resource}) => {
-			const filename = bySiteStructureFilenameGenerator(resource, {defaultFilename});
-			return {filename};
-		});
+	beforeStart({options}) {
+		this.defaultFilename = options.defaultFilename;
+	}
+
+	generateFilename({resource}) {
+		const filename = bySiteStructureFilenameGenerator(resource, {defaultFilename: this.defaultFilename});
+		return {filename};
 	}
 }
 

--- a/lib/plugins/generate-filenamy-by-site-structure-plugin.js
+++ b/lib/plugins/generate-filenamy-by-site-structure-plugin.js
@@ -2,15 +2,15 @@ import bySiteStructureFilenameGenerator from '../filename-generator/by-site-stru
 
 class GenerateFilenameBySiteStructurePlugin {
 	apply (registerAction) {
-		registerAction('beforeStart', this.beforeStart.bind(this))
-		registerAction('generateFilename', this.generateFilename.bind(this))
+		registerAction('beforeStart', this.beforeStart.bind(this));
+		registerAction('generateFilename', this.generateFilename.bind(this));
 	}
 
-	beforeStart({options}) {
+	beforeStart ({options}) {
 		this.defaultFilename = options.defaultFilename;
 	}
 
-	generateFilename({resource}) {
+	generateFilename ({resource}) {
 		const filename = bySiteStructureFilenameGenerator(resource, {defaultFilename: this.defaultFilename});
 		return {filename};
 	}

--- a/lib/plugins/generate-filenamy-by-type-plugin.js
+++ b/lib/plugins/generate-filenamy-by-type-plugin.js
@@ -6,13 +6,13 @@ class GenerateFilenameByTypePlugin {
 		registerAction('generateFilename', this.generateFilename.bind(this));
 	}
 
-	beforeStart({options}){
+	beforeStart ({options}) {
 		this.occupiedFilenames = [];
 		this.subdirectories = options.subdirectories;
 		this.defaultFilename = options.defaultFilename;
 	}
 
-	generateFilename({resource}){
+	generateFilename ({resource}) {
 		const filename = byTypeFilenameGenerator(resource, {
 			subdirectories: this.subdirectories,
 			defaultFilename: this.defaultFilename},

--- a/lib/plugins/generate-filenamy-by-type-plugin.js
+++ b/lib/plugins/generate-filenamy-by-type-plugin.js
@@ -2,18 +2,23 @@ import byTypeFilenameGenerator from '../filename-generator/by-type.js';
 
 class GenerateFilenameByTypePlugin {
 	apply (registerAction) {
-		let occupiedFilenames, subdirectories, defaultFilename;
+		registerAction('beforeStart', this.beforeStart.bind(this));
+		registerAction('generateFilename', this.generateFilename.bind(this));
+	}
 
-		registerAction('beforeStart', ({options}) => {
-			occupiedFilenames = [];
-			subdirectories = options.subdirectories;
-			defaultFilename = options.defaultFilename;
-		});
-		registerAction('generateFilename', ({resource}) => {
-			const filename = byTypeFilenameGenerator(resource, {subdirectories, defaultFilename}, occupiedFilenames);
-			occupiedFilenames.push(filename);
-			return {filename};
-		});
+	beforeStart({options}){
+		this.occupiedFilenames = [];
+		this.subdirectories = options.subdirectories;
+		this.defaultFilename = options.defaultFilename;
+	}
+
+	generateFilename({resource}){
+		const filename = byTypeFilenameGenerator(resource, {
+			subdirectories: this.subdirectories,
+			defaultFilename: this.defaultFilename},
+		this.occupiedFilenames);
+		this.occupiedFilenames.push(filename);
+		return {filename};
 	}
 }
 

--- a/lib/plugins/get-relative-path-reference-plugin.js
+++ b/lib/plugins/get-relative-path-reference-plugin.js
@@ -2,14 +2,16 @@ import { getRelativePath } from '../utils/index.js';
 
 class GetRelativePathReferencePlugin {
 	apply (registerAction) {
-		registerAction('getReference', ({resource, parentResource}) => {
-			if (resource) {
-				const relativePath = getRelativePath(parentResource.getFilename(), resource.getFilename());
-				return { reference: relativePath };
-			}
+		registerAction('getReference', this.getReference.bind(this));
+	}
 
-			return { reference: null };
-		});
+	getReference({resource, parentResource}){
+		if (resource) {
+			const relativePath = getRelativePath(parentResource.getFilename(), resource.getFilename());
+			return { reference: relativePath };
+		}
+
+		return { reference: null };
 	}
 }
 

--- a/lib/plugins/get-relative-path-reference-plugin.js
+++ b/lib/plugins/get-relative-path-reference-plugin.js
@@ -5,7 +5,7 @@ class GetRelativePathReferencePlugin {
 		registerAction('getReference', this.getReference.bind(this));
 	}
 
-	getReference({resource, parentResource}){
+	getReference ({resource, parentResource}) {
 		if (resource) {
 			const relativePath = getRelativePath(parentResource.getFilename(), resource.getFilename());
 			return { reference: relativePath };

--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -3,32 +3,36 @@ import fs from 'fs-extra';
 
 class SaveResourceToFileSystemPlugin {
 	apply (registerAction) {
-		let absoluteDirectoryPath, loadedResources = [];
+		this.loadedResources = []
 
-		registerAction('beforeStart', ({options}) => {
-			if (!options.directory || typeof options.directory !== 'string') {
-				throw new Error(`Incorrect directory ${options.directory}`);
-			}
+		registerAction('beforeStart', this.beforeStart.bind(this));
+		registerAction('saveResource', this.saveResource.bind(this));
+		registerAction('error', this.error.bind(this));
+	}
 
-			absoluteDirectoryPath = path.resolve(process.cwd(), options.directory);
+	beforeStart({options}){
+		if (!options.directory || typeof options.directory !== 'string') {
+			throw new Error(`Incorrect directory ${options.directory}`);
+		}
 
-			if (fs.existsSync(absoluteDirectoryPath)) {
-				throw new Error(`Directory ${absoluteDirectoryPath} exists`);
-			}
-		});
+		this.absoluteDirectoryPath = path.resolve(process.cwd(), options.directory);
 
-		registerAction('saveResource', async ({resource}) => {
-			const filename = path.join(absoluteDirectoryPath, resource.getFilename());
-			const text = resource.getText();
-			await fs.outputFile(filename, text, { encoding: resource.getEncoding() });
-			loadedResources.push(resource);
-		});
+		if (fs.existsSync(this.absoluteDirectoryPath)) {
+			throw new Error(`Directory ${this.absoluteDirectoryPath} exists`);
+		}
+	}
 
-		registerAction('error', async () => {
-			if (loadedResources.length > 0) {
-				await fs.remove(absoluteDirectoryPath);
-			}
-		});
+	async saveResource({resource}){
+		const filename = path.join(this.absoluteDirectoryPath, resource.getFilename());
+		const text = resource.getText();
+		await fs.outputFile(filename, text, { encoding: resource.getEncoding() });
+		this.loadedResources.push(resource);
+	}
+
+	async error(){
+		if (this.loadedResources.length > 0) {
+			await fs.remove(this.absoluteDirectoryPath);
+		}
 	}
 }
 

--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -3,14 +3,14 @@ import fs from 'fs-extra';
 
 class SaveResourceToFileSystemPlugin {
 	apply (registerAction) {
-		this.loadedResources = []
+		this.loadedResources = [];
 
 		registerAction('beforeStart', this.beforeStart.bind(this));
 		registerAction('saveResource', this.saveResource.bind(this));
 		registerAction('error', this.error.bind(this));
 	}
 
-	beforeStart({options}){
+	beforeStart ({options}) {
 		if (!options.directory || typeof options.directory !== 'string') {
 			throw new Error(`Incorrect directory ${options.directory}`);
 		}
@@ -22,14 +22,14 @@ class SaveResourceToFileSystemPlugin {
 		}
 	}
 
-	async saveResource({resource}){
+	async saveResource ({resource}) {
 		const filename = path.join(this.absoluteDirectoryPath, resource.getFilename());
 		const text = resource.getText();
 		await fs.outputFile(filename, text, { encoding: resource.getEncoding() });
 		this.loadedResources.push(resource);
 	}
 
-	async error(){
+	async error () {
 		if (this.loadedResources.length > 0) {
 			await fs.remove(this.absoluteDirectoryPath);
 		}


### PR DESCRIPTION
# What
This PR aims to refactor the core library plugins to make them more extendable without changing any of the functional implementation.

# How
Currently, though the plugins are exposed, they are not really extendable / modifiable. This PR aims to slightly address that issue

# Why
Currently the plugins rely on shared state through references to variables passed into closures. Moving the state of the plugin and closures to class properties and methods enables more adaptability for extending these plugins. For example

```js
import GenerateFilenameBySiteStructurePlugin from 'the/lib/path'

class MyCustomFileNamePlugins extends GenerateFilenameBySiteStructurePlugin {
      generateFilename({resource}){
             const {filename} = super.generateFilename({resource})
              // Do custom stuff here
              return {filename}
      }
}
```

Any input on what you think for this would be much appreciated!
This should in theory make things easier to unit test also :raised_hands: 

