### PR TITLE
Revert "RFC: Refactor builtin plugins to expose class properties (#506)"

### DIFF
--- a/lib/plugins/generate-filenamy-by-site-structure-plugin.js
+++ b/lib/plugins/generate-filenamy-by-site-structure-plugin.js
@@ -2,17 +2,15 @@ import bySiteStructureFilenameGenerator from '../filename-generator/by-site-stru
 
 class GenerateFilenameBySiteStructurePlugin {
 	apply (registerAction) {
-		registerAction('beforeStart', this.beforeStart.bind(this));
-		registerAction('generateFilename', this.generateFilename.bind(this));
-	}
+		let defaultFilename;
 
-	beforeStart ({options}) {
-		this.defaultFilename = options.defaultFilename;
-	}
-
-	generateFilename ({resource}) {
-		const filename = bySiteStructureFilenameGenerator(resource, {defaultFilename: this.defaultFilename});
-		return {filename};
+		registerAction('beforeStart', ({options}) => {
+			defaultFilename = options.defaultFilename;
+		});
+		registerAction('generateFilename', ({resource}) => {
+			const filename = bySiteStructureFilenameGenerator(resource, {defaultFilename});
+			return {filename};
+		});
 	}
 }
 

--- a/lib/plugins/generate-filenamy-by-type-plugin.js
+++ b/lib/plugins/generate-filenamy-by-type-plugin.js
@@ -2,23 +2,18 @@ import byTypeFilenameGenerator from '../filename-generator/by-type.js';
 
 class GenerateFilenameByTypePlugin {
 	apply (registerAction) {
-		registerAction('beforeStart', this.beforeStart.bind(this));
-		registerAction('generateFilename', this.generateFilename.bind(this));
-	}
+		let occupiedFilenames, subdirectories, defaultFilename;
 
-	beforeStart ({options}) {
-		this.occupiedFilenames = [];
-		this.subdirectories = options.subdirectories;
-		this.defaultFilename = options.defaultFilename;
-	}
-
-	generateFilename ({resource}) {
-		const filename = byTypeFilenameGenerator(resource, {
-			subdirectories: this.subdirectories,
-			defaultFilename: this.defaultFilename},
-		this.occupiedFilenames);
-		this.occupiedFilenames.push(filename);
-		return {filename};
+		registerAction('beforeStart', ({options}) => {
+			occupiedFilenames = [];
+			subdirectories = options.subdirectories;
+			defaultFilename = options.defaultFilename;
+		});
+		registerAction('generateFilename', ({resource}) => {
+			const filename = byTypeFilenameGenerator(resource, {subdirectories, defaultFilename}, occupiedFilenames);
+			occupiedFilenames.push(filename);
+			return {filename};
+		});
 	}
 }
 

--- a/lib/plugins/get-relative-path-reference-plugin.js
+++ b/lib/plugins/get-relative-path-reference-plugin.js
@@ -2,16 +2,14 @@ import { getRelativePath } from '../utils/index.js';
 
 class GetRelativePathReferencePlugin {
 	apply (registerAction) {
-		registerAction('getReference', this.getReference.bind(this));
-	}
+		registerAction('getReference', ({resource, parentResource}) => {
+			if (resource) {
+				const relativePath = getRelativePath(parentResource.getFilename(), resource.getFilename());
+				return { reference: relativePath };
+			}
 
-	getReference ({resource, parentResource}) {
-		if (resource) {
-			const relativePath = getRelativePath(parentResource.getFilename(), resource.getFilename());
-			return { reference: relativePath };
-		}
-
-		return { reference: null };
+			return { reference: null };
+		});
 	}
 }
 

--- a/lib/plugins/save-resource-to-fs-plugin.js
+++ b/lib/plugins/save-resource-to-fs-plugin.js
@@ -3,36 +3,32 @@ import fs from 'fs-extra';
 
 class SaveResourceToFileSystemPlugin {
 	apply (registerAction) {
-		this.loadedResources = [];
+		let absoluteDirectoryPath, loadedResources = [];
 
-		registerAction('beforeStart', this.beforeStart.bind(this));
-		registerAction('saveResource', this.saveResource.bind(this));
-		registerAction('error', this.error.bind(this));
-	}
+		registerAction('beforeStart', ({options}) => {
+			if (!options.directory || typeof options.directory !== 'string') {
+				throw new Error(`Incorrect directory ${options.directory}`);
+			}
 
-	beforeStart ({options}) {
-		if (!options.directory || typeof options.directory !== 'string') {
-			throw new Error(`Incorrect directory ${options.directory}`);
-		}
+			absoluteDirectoryPath = path.resolve(process.cwd(), options.directory);
 
-		this.absoluteDirectoryPath = path.resolve(process.cwd(), options.directory);
+			if (fs.existsSync(absoluteDirectoryPath)) {
+				throw new Error(`Directory ${absoluteDirectoryPath} exists`);
+			}
+		});
 
-		if (fs.existsSync(this.absoluteDirectoryPath)) {
-			throw new Error(`Directory ${this.absoluteDirectoryPath} exists`);
-		}
-	}
+		registerAction('saveResource', async ({resource}) => {
+			const filename = path.join(absoluteDirectoryPath, resource.getFilename());
+			const text = resource.getText();
+			await fs.outputFile(filename, text, { encoding: resource.getEncoding() });
+			loadedResources.push(resource);
+		});
 
-	async saveResource ({resource}) {
-		const filename = path.join(this.absoluteDirectoryPath, resource.getFilename());
-		const text = resource.getText();
-		await fs.outputFile(filename, text, { encoding: resource.getEncoding() });
-		this.loadedResources.push(resource);
-	}
-
-	async error () {
-		if (this.loadedResources.length > 0) {
-			await fs.remove(this.absoluteDirectoryPath);
-		}
+		registerAction('error', async () => {
+			if (loadedResources.length > 0) {
+				await fs.remove(absoluteDirectoryPath);
+			}
+		});
 	}
 }
 


### PR DESCRIPTION
This reverts commit 5dde8ec21fdf234fa5abdf72dfb9ae4949f5ff0f.

It was decided to revert the changes (see [comment](https://github.com/website-scraper/node-website-scraper/pull/506#issuecomment-1243416683)) and remove plugins export (will be done in separate PR)