### PR TITLE
#510 Remove plugin exports and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Plugins allow to extend scraper behaviour
     * [getReference](#getreference)
 
 ##### Built-in plugins
-Scraper has built-in plugins which are used by default if not overwritten with custom plugins. You can find them in [lib/plugins](lib/plugins) directory.
+Scraper has built-in plugins which are used by default if not overwritten with custom plugins. You can find them in [lib/plugins](lib/plugins) directory. Thease plugins are intended for internal use but can be coppied if the behaviour of the plugins needs to be extended / changed.
 
 ##### Existing plugins
 * [website-scraper-puppeteer](https://github.com/website-scraper/website-scraper-puppeteer) - download dynamic (rendered with js) websites using puppeteer

--- a/README.md
+++ b/README.md
@@ -220,10 +220,7 @@ Plugins allow to extend scraper behaviour
     * [getReference](#getreference)
 
 ##### Built-in plugins
-Scraper has built-in plugins which are used by default if not overwritten with custom plugins. You can find them in [lib/plugins](https://github.com/website-scraper/node-website-scraper/tree/master/lib/plugins) directory or get them using 
-```javascript
-import * as plugins from 'website-scraper/plugins';
-```
+Scraper has built-in plugins which are used by default if not overwritten with custom plugins. You can find them in [lib/plugins](lib/plugins) directory.
 
 ##### Existing plugins
 * [website-scraper-puppeteer](https://github.com/website-scraper/website-scraper-puppeteer) - download dynamic (rendered with js) websites using puppeteer
@@ -231,7 +228,6 @@ import * as plugins from 'website-scraper/plugins';
 * [website-scraper-existing-directory](https://github.com/website-scraper/website-scraper-existing-directory) - save files to existing directory
 
 ##### Create plugin
-**Note:** before creating new plugins consider using/extending/contributing to [existing plugins](#existing-plugins).
 
 Plugin is object with `.apply` method, can be used to change scraper behavior.
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "type": "module",
   "exports": {
     ".": "./index.mjs",
-    "./defaultOptions": "./lib/config/defaults.js",
-    "./plugins": "./lib/plugins/index.js"
+    "./defaultOptions": "./lib/config/defaults.js"
   },
   "scripts": {
     "test": "c8 --all --reporter=text --reporter=lcov mocha --recursive --timeout 7000 ./test/unit/ ./test/functional",

--- a/test/unit/scraper-test.js
+++ b/test/unit/scraper-test.js
@@ -5,9 +5,10 @@ import fs from 'fs-extra';
 import path from 'path';
 import Scraper from '../../lib/scraper.js';
 import Resource from '../../lib/resource.js';
+import * as plugins from '../../lib/plugins/index.js';
 
 import defaultOptions from 'website-scraper/defaultOptions';
-import * as plugins from 'website-scraper/plugins';
+
 
 const testDirname = './test/unit/.scraper-test';
 


### PR DESCRIPTION
# What
Removing plugin exports as discussed in #510 

# Why 
So that plugin code is not too tightly coupled to custom plugin implementations

# How
Remove plugin exports and updated documentation 

# Notes
Note: This should not be merged until V6